### PR TITLE
fixed Draw_String only showing a single character plus garbage.

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -522,7 +522,10 @@ void Draw_String (int x, int y, const char *str)
 	for(int i = 0; *str != 0; ++str)
 	{
 		if (*str != 32)
+		{
 			Draw_FillCharacterQuad(x, y, *str, vertices + i * 6);
+			i++;
+		}
 		x += 8;
 	}
 


### PR DESCRIPTION
this fixes:
* `src_showfps 1` command
* `src_devstats 1` command
* team notifications
* much more...

tbh, I just wanted the `src_showfps` command to work.