### PR TITLE
Makefile fix for DEBUG=1 on Linux

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -66,7 +66,6 @@ do_strip=
 else
 DFLAGS += -DNDEBUG
 CFLAGS += -O2
-CFLAGS += -std=gnu99
 CFLAGS += $(call check_gcc,-fweb,)
 CFLAGS += $(call check_gcc,-frename-registers,)
 cmd_strip=$(STRIP) $(1)
@@ -74,6 +73,7 @@ define do_strip
 	$(call cmd_strip,$(1));
 endef
 endif
+CFLAGS += -std=gnu99
 CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR
 
 ifeq ($(DO_USERDIRS),1)

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -67,7 +67,6 @@ else
 DFLAGS += -DNDEBUG
 CFLAGS += -O2
 CFLAGS += -std=gnu99
-CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR
 CFLAGS += $(call check_gcc,-fweb,)
 CFLAGS += $(call check_gcc,-frename-registers,)
 cmd_strip=$(STRIP) $(1)
@@ -75,6 +74,7 @@ define do_strip
 	$(call cmd_strip,$(1));
 endef
 endif
+CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR
 
 ifeq ($(DO_USERDIRS),1)
 CFLAGS += -DDO_USERDIRS=1


### PR DESCRIPTION
-I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR was not being passed to the compiler, resulting in the following error when doing make DEBUG=1
```
~/vkQuake/Quake$ make DEBUG=1 
cc  -DDEBUG -c -Wall -Wno-trigraphs  -g -DUSE_SDL2 -DUSE_CODEC_WAVE -DUSE_CODEC_VORBIS  -DUSE_CODEC_MP3 -I/usr/include/SDL2 -D_REENTRANT -o gl_vidsdl.o gl_vidsdl.c
gl_vidsdl.c: In function ‘GL_InitInstance’:
gl_vidsdl.c:527:15: error: ‘PLATFORM_SURF_EXT’ undeclared (first use in this function)
    if (strcmp(PLATFORM_SURF_EXT, instance_extensions[i].extensionName) == 0)
               ^
```