### PR TITLE
use _DEBUG consistently

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -60,7 +60,7 @@ DFLAGS ?=
 CFLAGS ?= -Wall -Wno-trigraphs
 CFLAGS += $(CPUFLAGS)
 ifneq ($(DEBUG),0)
-DFLAGS += -DDEBUG
+DFLAGS += -D_DEBUG
 CFLAGS += -g
 do_strip=
 else

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -54,7 +54,7 @@ CFLAGS ?= -Wall -Wno-trigraphs
 CFLAGS += $(CPUFLAGS)
 
 ifneq ($(DEBUG),0)
-DFLAGS += -DDEBUG
+DFLAGS += -D_DEBUG
 CFLAGS += -g
 do_strip=
 else

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -136,7 +136,7 @@ int Datagram_SendMessage (qsocket_t *sock, sizebuf_t *data)
 	unsigned int	dataLen;
 	unsigned int	eom;
 
-#ifdef DEBUG
+#ifdef _DEBUG
 	if (data->cursize == 0)
 		Sys_Error("Datagram_SendMessage: zero length message\n");
 
@@ -262,7 +262,7 @@ int Datagram_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 {
 	int	packetLen;
 
-#ifdef DEBUG
+#ifdef _DEBUG
 	if (data->cursize == 0)
 		Sys_Error("Datagram_SendUnreliableMessage: zero length message\n");
 


### PR DESCRIPTION
Quake/Makefile and Makefile.w32 defines DEBUG.
the vcproj files defines _DEBUG.

Some sources are testing against _DEBUG, and some DEBUG.