### PR TITLE
small stuff, sync with qs

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -70,7 +70,6 @@ define do_strip
 	$(call cmd_strip,$(1));
 endef
 endif
-CFLAGS += -std=gnu99
 CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR
 
 ifeq ($(DO_USERDIRS),1)

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -249,11 +249,11 @@ GLOBJS = \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
+	gl_heap.o \
 	r_sprite.o \
 	r_alias.o \
 	r_brush.o \
-	gl_model.o \
-	gl_heap.o
+	gl_model.o
 
 OBJS := strlcat.o \
 	strlcpy.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -240,11 +240,11 @@ GLOBJS = \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
+	gl_heap.o \
 	r_sprite.o \
 	r_alias.o \
 	r_brush.o \
-	gl_model.o \
-	gl_heap.o
+	gl_model.o
 
 OBJS := strlcat.o \
 	strlcpy.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -1,6 +1,7 @@
 # GNU Makefile for compiling Win32 vkQuake.exe using MinGW or MinGW-w64.
 # Usage: "make -f Makefile.w32"
 # To cross-compile on Linux hosts, see the "build_cross_win32*.sh" scripts.
+# "make VK_SDK_PATH=/path/to/vksdk" to specify the Vulkan SDK root
 # "make DEBUG=1" to build a debug client.
 # "make SDL_CONFIG=/path/to/sdl-config" to override the locally included SDL versions.
 # "make WINSOCK2=1" to use WinSock2 api instead of old WinSock 1.1.

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -50,7 +50,7 @@ CFLAGS ?= -m64 -Wall -Wno-trigraphs
 CFLAGS += $(CPUFLAGS)
 
 ifneq ($(DEBUG),0)
-DFLAGS += -DDEBUG
+DFLAGS += -D_DEBUG
 CFLAGS += -g
 do_strip=
 else
@@ -238,11 +238,11 @@ GLOBJS = \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
+	gl_heap.o \
 	r_sprite.o \
 	r_alias.o \
 	r_brush.o \
-	gl_model.o \
-	gl_heap.o
+	gl_model.o
 
 OBJS := strlcat.o \
 	strlcpy.o \

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -1,6 +1,7 @@
 # GNU Makefile for compiling Win64 vkQuake.exe using MinGW-w64.
 # Usage: "make -f Makefile.w64"
 # To cross-compile on Linux hosts, see the "build_cross_win32*.sh" scripts.
+# "make VK_SDK_PATH=/path/to/vksdk" to specify the Vulkan SDK root
 # "make DEBUG=1" to build a debug client.
 # "make SDL_CONFIG=/path/to/sdl-config" to override the locally included SDL versions.
 # "make WINSOCK2=0" to use the old WinSock 1.1 api (NOT RECOMMENDED)

--- a/Quake/arch_def.h
+++ b/Quake/arch_def.h
@@ -59,7 +59,7 @@
 #   endif
 
 #elif defined(__MORPHOS__) || defined(__AROS__) || defined(AMIGAOS)	|| \
-      defined(__amigaos__) || defined(__amigados__)			|| \
+      defined(__amigaos__) || defined(__amigaos4__) ||defined(__amigados__) || \
       defined(AMIGA) || defined(_AMIGA) || defined(__AMIGA__)
 
 #   if !defined(PLATFORM_AMIGA)
@@ -108,6 +108,13 @@
 #endif	/* PLATFORM_BSD (for convenience) */
 
 
+#if defined(PLATFORM_AMIGA) && !defined(PLATFORM_AMIGAOS3)
+#   if !defined(__MORPHOS__) && !defined(__AROS__) && !defined(__amigaos4__)
+#	define	PLATFORM_AMIGAOS3	1
+#   endif
+#endif	/* PLATFORM_AMIGAOS3 (for convenience) */
+
+
 #if defined(_WIN64)
 #	define	PLATFORM_STRING	"Win64"
 #elif defined(_WIN32)
@@ -130,6 +137,8 @@
 #	define	PLATFORM_STRING	"MorphOS"
 #elif defined(__AROS__)
 #	define	PLATFORM_STRING	"AROS"
+#elif defined(__amigaos4__)
+#	define	PLATFORM_STRING	"AmigaOS4"
 #elif defined(PLATFORM_AMIGA)
 #	define	PLATFORM_STRING	"AmigaOS"
 #elif defined(__QNX__) || defined(__QNXNTO__)

--- a/Quake/filenames.h
+++ b/Quake/filenames.h
@@ -1,0 +1,194 @@
+/* Macros for taking apart, interpreting and processing file names.
+ *
+ * These are here because some non-Posix (a.k.a. DOSish) systems have
+ * drive letter brain-damage at the beginning of an absolute file name,
+ * use forward- and back-slash in path names interchangeably, and
+ * some of them have case-insensitive file names.
+ *
+ * Copyright 2000, 2001, 2007 Free Software Foundation, Inc.
+ *
+ * This is based on filenames.h from BFD, the Binary File Descriptor
+ * library, changed further for our needs.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ */
+
+#ifndef FILENAMES_H
+#define FILENAMES_H
+
+#include <string.h>
+
+/* ---------------------- Windows, DOS, OS2: ---------------------- */
+#if defined(__MSDOS__) || defined(MSDOS) || defined(__DOS__)	|| \
+    defined(__DJGPP__) || defined(__OS2__) || defined(__EMX__)	|| \
+    defined(_WIN32) || defined(__CYGWIN__)
+
+#define HAVE_DOS_BASED_FILE_SYSTEM 1
+#define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
+
+#define HAS_DRIVE_SPEC(f)	((f)[0] && ((f)[1] == ':'))
+#define STRIP_DRIVE_SPEC(f)	((f) + 2)
+#define IS_DIR_SEPARATOR(c)	((c) == '/' || (c) == '\\')
+/* both '/' and '\\' work as dir separator.  djgpp likes changing
+ * '\\' into '/', so I define DIR_SEPARATOR_CHAR as '/' for djgpp,
+ * '\\' otherwise.  */
+#ifdef __DJGPP__
+#define DIR_SEPARATOR_CHAR	'/'
+#define DIR_SEPARATOR_STR	"/"
+#else
+#define DIR_SEPARATOR_CHAR	'\\'
+#define DIR_SEPARATOR_STR	"\\"
+#endif
+/* Note that IS_ABSOLUTE_PATH accepts d:foo as well, although it is
+   only semi-absolute.  This is because the users of IS_ABSOLUTE_PATH
+   want to know whether to prepend the current working directory to
+   a file name, which should not be done with a name like d:foo.  */
+#define IS_ABSOLUTE_PATH(f)	(IS_DIR_SEPARATOR((f)[0]) || HAS_DRIVE_SPEC((f)))
+
+#ifdef __cplusplus
+static inline char *FIND_FIRST_DIRSEP(char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    char *p1 = strchr(_the_path, '/');
+    char *p2 = strchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 < p2)? p1 : p2;
+}
+static inline char *FIND_LAST_DIRSEP (char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    char *p1 = strrchr(_the_path, '/');
+    char *p2 = strrchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 > p2)? p1 : p2;
+}
+static inline const char *FIND_FIRST_DIRSEP(const char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    const char *p1 = strchr(_the_path, '/');
+    const char *p2 = strchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 < p2)? p1 : p2;
+}
+static inline const char *FIND_LAST_DIRSEP (const char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    const char *p1 = strrchr(_the_path, '/');
+    const char *p2 = strrchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 > p2)? p1 : p2;
+}
+#else
+static inline char *FIND_FIRST_DIRSEP(const char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    char *p1 = strchr(_the_path, '/');
+    char *p2 = strchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 < p2)? p1 : p2;
+}
+static inline char *FIND_LAST_DIRSEP (const char *_the_path) {
+/* FIXME: What about C:FOO ? */
+    char *p1 = strrchr(_the_path, '/');
+    char *p2 = strrchr(_the_path, '\\');
+    if (p1 == NULL) return p2;
+    if (p2 == NULL) return p1;
+    return (p1 > p2)? p1 : p2;
+}
+#endif /* C++ */
+
+/* ----------------- AmigaOS, MorphOS, AROS, etc: ----------------- */
+#elif defined(__MORPHOS__) || defined(__AROS__) || defined(AMIGAOS)	|| \
+      defined(__amigaos__) || defined(__amigaos4__) ||defined(__amigados__) || \
+      defined(AMIGA) || defined(_AMIGA) || defined(__AMIGA__)
+
+#define HAS_DRIVE_SPEC(f)	(0) /* */
+#define STRIP_DRIVE_SPEC(f)	(f) /* */
+#define IS_DIR_SEPARATOR(c)	((c) == '/' || (c) == ':')
+#define DIR_SEPARATOR_CHAR	'/'
+#define DIR_SEPARATOR_STR	"/"
+#define IS_ABSOLUTE_PATH(f)	(IS_DIR_SEPARATOR((f)[0]) || (strchr((f), ':')))
+#define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
+
+#ifdef __cplusplus
+static inline char *FIND_FIRST_DIRSEP(char *_the_path) {
+    char *p = strchr(_the_path, ':');
+    if (p != NULL) return p;
+    return strchr(_the_path, '/');
+}
+static inline char *FIND_LAST_DIRSEP (char *_the_path) {
+    char *p = strrchr(_the_path, '/');
+    if (p != NULL) return p;
+    return strchr(_the_path, ':');
+}
+static inline const char *FIND_FIRST_DIRSEP(const char *_the_path) {
+    const char *p = strchr(_the_path, ':');
+    if (p != NULL) return p;
+    return strchr(_the_path, '/');
+}
+static inline const char *FIND_LAST_DIRSEP (const char *_the_path) {
+    const char *p = strrchr(_the_path, '/');
+    if (p != NULL) return p;
+    return strchr(_the_path, ':');
+}
+#else
+static inline char *FIND_FIRST_DIRSEP(const char *_the_path) {
+    char *p = strchr(_the_path, ':');
+    if (p != NULL) return p;
+    return strchr(_the_path, '/');
+}
+static inline char *FIND_LAST_DIRSEP (const char *_the_path) {
+    char *p = strrchr(_the_path, '/');
+    if (p != NULL) return p;
+    return strchr(_the_path, ':');
+}
+#endif /* C++ */
+
+/* ---------------------- assumed UNIX-ish : ---------------------- */
+#else /* */
+
+#define IS_DIR_SEPARATOR(c)	((c) == '/')
+#define DIR_SEPARATOR_CHAR	'/'
+#define DIR_SEPARATOR_STR	"/"
+#define IS_ABSOLUTE_PATH(f)	(IS_DIR_SEPARATOR((f)[0]))
+#define HAS_DRIVE_SPEC(f)	(0)
+#define STRIP_DRIVE_SPEC(f)	(f)
+
+#ifdef __cplusplus
+static inline char *FIND_FIRST_DIRSEP(char *_the_path) {
+    return strchr(_the_path, '/');
+}
+static inline char *FIND_LAST_DIRSEP (char *_the_path) {
+    return strrchr(_the_path, '/');
+}
+static inline const char *FIND_FIRST_DIRSEP(const char *_the_path) {
+    return strchr(_the_path, '/');
+}
+static inline const char *FIND_LAST_DIRSEP (const char *_the_path) {
+    return strrchr(_the_path, '/');
+}
+#else
+static inline char *FIND_FIRST_DIRSEP(const char *_the_path) {
+    return strchr(_the_path, '/');
+}
+static inline char *FIND_LAST_DIRSEP (const char *_the_path) {
+    return strrchr(_the_path, '/');
+}
+#endif /* C++ */
+
+#endif
+
+#endif /* FILENAMES_H */
+

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -923,6 +923,8 @@ int SCR_ModalMessage (const char *text, float timeout) //johnfitz -- timeout
 	} while (lastchar != 'y' && lastchar != 'Y' &&
 		 lastchar != 'n' && lastchar != 'N' &&
 		 lastkey != K_ESCAPE &&
+		 lastkey != K_ABUTTON &&
+		 lastkey != K_BBUTTON &&
 		 time2 <= time1);
 	Key_EndInputGrab ();
 
@@ -933,7 +935,7 @@ int SCR_ModalMessage (const char *text, float timeout) //johnfitz -- timeout
 		return false;
 	//johnfitz
 
-	return (lastchar == 'y' || lastchar == 'Y');
+	return (lastchar == 'y' || lastchar == 'Y' || lastkey == K_ABUTTON);
 }
 
 

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -23,11 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#if defined(USE_SDL2)
 #include <SDL2/SDL.h>
-#else
-#include <SDL/SDL.h>
-#endif
 #else
 #include "SDL.h"
 #endif

--- a/Quake/net_sys.h
+++ b/Quake/net_sys.h
@@ -65,6 +65,11 @@ typedef int	sys_socket_t;
 #define	INVALID_SOCKET	(-1)
 #define	SOCKET_ERROR	(-1)
 
+#if defined(__APPLE__) && defined(SO_NKE) && !defined(SO_NOADDRERR)
+				/* ancient Mac OS X SDKs 10.2 and older are missing socklen_t */
+typedef int	socklen_t;			/* defining as signed int to match the old api */
+#endif	/* ancient OSX SDKs */
+
 #define	SOCKETERRNO	errno
 #define	ioctlsocket	ioctl
 #define	closesocket	close
@@ -116,7 +121,7 @@ typedef unsigned int	in_addr_t;	/* u_int32_t */
 #define	selectsocket(_N,_R,_W,_E,_T)		\
 	WaitSelect((_N),(_R),(_W),(_E),(_T),NULL)
 #define	IOCTLARG_P(x)	(char *) x
-#if defined(__AMIGA__) && !defined(__MORPHOS__)
+#if defined(__amigaos4__) || defined(PLATFORM_AMIGAOS3)
 #define	inet_ntoa(x) Inet_NtoA(x.s_addr) /* Inet_NtoA(*(ULONG*)&x) */
 #define	h_errno Errno()
 #endif

--- a/Quake/pl_linux.c
+++ b/Quake/pl_linux.c
@@ -23,11 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#if defined(USE_SDL2)
 #include <SDL2/SDL.h>
-#else
-#include <SDL/SDL.h>
-#endif
 #else
 #include "SDL.h"
 #endif
@@ -52,13 +48,8 @@ void PL_SetWindowIcon (void)
 		return;
 	/* make pure magenta (#ff00ff) tranparent */
 	colorkey = SDL_MapRGB(icon->format, 255, 0, 255);
-#if defined(USE_SDL2)
 	SDL_SetColorKey(icon, SDL_TRUE, colorkey);
 	SDL_SetWindowIcon((SDL_Window*) VID_GetWindow(), icon);
-#else
-	SDL_SetColorKey(icon, SDL_SRCCOLORKEY, colorkey);
-	SDL_WM_SetIcon(icon, NULL);
-#endif
 	SDL_FreeSurface(icon);
 }
 
@@ -70,7 +61,6 @@ void PL_VID_Shutdown (void)
 char *PL_GetClipboardData (void)
 {
 	char *data = NULL;
-#if defined(USE_SDL2)
 	char *cliptext = SDL_GetClipboardText();
 
 	if (cliptext != NULL)
@@ -84,7 +74,6 @@ char *PL_GetClipboardData (void)
 		data = (char *) Z_Malloc(size);
 		q_strlcpy (data, cliptext, size);
 	}
-#endif
 
 	return data;
 }

--- a/Quake/pl_osx.m
+++ b/Quake/pl_osx.m
@@ -23,11 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#if defined(USE_SDL2)
 #include <SDL2/SDL.h>
-#else
-#include <SDL/SDL.h>
-#endif
 #else
 #include "SDL.h"
 #endif

--- a/Quake/q_ctype.h
+++ b/Quake/q_ctype.h
@@ -63,8 +63,22 @@ static inline int q_isblank(int c)
 
 static inline int q_isspace(int c)
 {
-	return (q_isblank(c) || c == '\n' || c == '\r' ||
-				c == '\f' || c == '\v');
+	switch(c) {
+	case ' ':  case '\t':
+	case '\n': case '\r':
+	case '\f': case '\v': return 1;
+	}
+	return 0;
+}
+
+static inline int q_isgraph(int c)
+{
+	return (c > 0x20 && c <= 0x7e);
+}
+
+static inline int q_isprint(int c)
+{
+	return (c >= 0x20 && c <= 0x7e);
 }
 
 static inline int q_toascii(int c)
@@ -82,4 +96,4 @@ static inline int q_toupper(int c)
 	return ((q_islower(c)) ? (c & ~('a' - 'A')) : c);
 }
 
-#endif	/* Q_CTYPE_H */
+#endif /* Q_CTYPE_H */

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -38,7 +38,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	FITZQUAKE_VERSION	0.85	//johnfitz
 #define	QUAKESPASM_VERSION	0.92
-#define	QUAKESPASM_VER_PATCH	0	// helper to print a string like 0.91.0
+#define	QUAKESPASM_VER_PATCH	1	// helper to print a string like 0.91.0
 #define	VKQUAKE_VERSION		0.71
 #define	VKQUAKE_VER_PATCH	0	// helper to print a string like 0.91.0
 

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -830,6 +830,7 @@ void R_BuildLightMap (msurface_t *surf, byte *dest, int stride)
 
 	// add all the lightmaps
 		if (lightmap)
+		{
 			for (maps = 0 ; maps < MAXLIGHTMAPS && surf->styles[maps] != 255 ;
 				 maps++)
 			{
@@ -845,6 +846,7 @@ void R_BuildLightMap (msurface_t *surf, byte *dest, int stride)
 				}
 				//johnfitz
 			}
+		}
 
 	// add all the dynamic lights
 		if (surf->dlightframe == r_framecount)
@@ -867,9 +869,9 @@ void R_BuildLightMap (msurface_t *surf, byte *dest, int stride)
 			r = *bl++ >> 8;
 			g = *bl++ >> 8;
 			b = *bl++ >> 8;
-			if (r > 255) r = 255; *dest++ = r;
-			if (g > 255) g = 255; *dest++ = g;
-			if (b > 255) b = 255; *dest++ = b;
+			*dest++ = (r > 255)? 255 : r;
+			*dest++ = (g > 255)? 255 : g;
+			*dest++ = (b > 255)? 255 : b;
 			*dest++ = 255;
 		}
 	}

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -39,11 +39,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#if defined(USE_SDL2)
 #include <SDL2/SDL.h>
-#else
-#include <SDL/SDL.h>
-#endif
 #else
 #include "SDL.h"
 #endif

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -285,10 +285,7 @@ void Sys_Error (const char *error, ...)
 		SDL_Delay (3000);	/* show the console 3 more seconds */
 	}
 
-// shut down QHOST hooks if necessary
-//	DeinitConProc ();
-
-#if defined(_DEBUG) && defined(_WIN32)
+#ifdef _DEBUG
 	__debugbreak();
 #endif
 
@@ -314,9 +311,7 @@ void Sys_Printf (const char *fmt, ...)
 	/* SDL will put these into its own stdout log,
 	   so print to stdout even in graphical mode. */
 		fputs (text, stdout);
-#ifdef _WIN32
 		OutputDebugStringA(text);
-#endif
 	}
 }
 

--- a/Shaders/bintoc.c
+++ b/Shaders/bintoc.c
@@ -3,24 +3,24 @@
 
 int main(int argc, char** argv) {
     if(argc != 3)
-		return;
+	return 0;
 
     char* fn = argv[1];
     FILE* f = fopen(fn, "rb");
     printf("unsigned char %s[] = {\n", argv[2]);
     unsigned long n = 0;
 
-    while(!feof(f)) 
-	{
+    while(!feof(f)) {
         unsigned char c;
         if(fread(&c, 1, 1, f) == 0) break;
         printf("0x%.2X, ", (int)c);
         ++n;
         if(n % 10 == 0) printf("\n");
     }
-	
+
     fclose(f);
     printf("};\n");
 
-	printf("int %s_size = %d;\n", argv[2], n);	
+    printf("int %s_size = %ld;\n", argv[2], n);
+    return 0;
 }

--- a/Shaders/compile.sh
+++ b/Shaders/compile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #set your VULKAN_SDK location  before running
-VULKAN_SDK=~/VulkanSDK/1.0.21.1/x86_64/
+VULKAN_SDK=~/VulkanSDK/1.0.26.0/x86_64/
 if [[ ! -x "./bintoc" ]]
 then
 	gcc bintoc.c -o bintoc


### PR DESCRIPTION
- remove rest of the SDL1 refs from source
- remove unnecessary _WIN32 checks from windows source
- warning fixes for bintoc.c
- sync with quakespasm-0.92.0: (missed parts in SCR_ModalMessage() and R_BuildLightMap()
- sync with quakespasm tree: rest of the small stuff, for sake of symmetry
