### PR TITLE
Fix pWaitDstStageMask in vkQueueSubmit

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1821,7 +1821,7 @@ void GL_EndRendering (void)
 	if (err != VK_SUCCESS)
 		Sys_Error("vkEndCommandBuffer failed");
 
-	VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+	VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
 	VkSubmitInfo submit_info;
 	memset(&submit_info, 0, sizeof(submit_info));


### PR DESCRIPTION
The image acquired semaphore must be signaled before any pixels can be rendered to the swapchain image, so we need to wait at VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT instead of VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT.