### PR TITLE
Fix dstAccessMask in VkSubpassDependency

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1050,7 +1050,7 @@ static void GL_CreateRenderPasses()
 	subpass_dependencies[0].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 	subpass_dependencies[0].dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 	subpass_dependencies[0].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-	subpass_dependencies[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+	subpass_dependencies[0].dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 	subpass_dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
 	memset(&render_pass_create_info, 0, sizeof(render_pass_create_info));


### PR DESCRIPTION
The shaders in the second subpass read the output of the first using subpassInput, so dstAccessMask should be VK_ACCESS_INPUT_ATTACHMENT_READ_BIT, not VK_ACCESS_SHADER_READ_BIT.