### PR TITLE
Remove VK_USER_PLATFORM_XCB_KHR from Makefile

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -71,7 +71,7 @@ define do_strip
 	$(call cmd_strip,$(1));
 endef
 endif
-CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX -DVK_USE_PLATFORM_XCB_KHR
+CFLAGS += -I$(VULKAN_INCLUDE_DIR) -DLINUX
 
 ifeq ($(DO_USERDIRS),1)
 CFLAGS += -DDO_USERDIRS=1


### PR DESCRIPTION
Allows compiling vkQuake without X headers present. Leftover from c652faa.