### PR TITLE
Fix LDFLAGS

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -52,7 +52,7 @@ STRIP ?= strip
 #CPUFLAGS= -mtune=k8
 #CPUFLAGS= -march=atom
 CPUFLAGS=
-LDFLAGS = -L$(VULKAN_SDK)/lib
+LDFLAGS += -L$(VULKAN_SDK)/lib
 DFLAGS ?=
 CFLAGS ?= -Wall -Wno-trigraphs
 CFLAGS += $(CPUFLAGS)


### PR DESCRIPTION
LDFLAGS being replaced rather than ammended, prevents additional libraries from being specified.
EG:"-lopusfile -lFLAC -lmikmod"