### PR TITLE
Allow reallocating dynamic vertex, index and uniform buffers (fixes #164)

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1962,6 +1962,7 @@ void GL_EndRendering (qboolean swapchain_acquired)
 		Sys_Error("vkQueueSubmit failed");
 
 	vulkan_globals.device_idle = false;
+	R_DeletePendingResources();
 
 	if (swapchain_acquired == true) {
 		VkPresentInfoKHR present_info;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -360,6 +360,8 @@ void R_DrawSpriteModel (entity_t *e);
 
 void R_DrawTextureChains_Water (qmodel_t *model, entity_t *ent, texchain_t chain);
 
+void R_DeletePendingResources (void);
+
 void GL_BuildLightmaps (void);
 void GL_DeleteBModelVertexBuffer (void);
 void GL_BuildBModelVertexBuffer (void);


### PR DESCRIPTION
I'm a complete Vulkan and computer graphics newbie and this is the best thing I could come up with in a few hours, but it seems to work here with no validation errors. Let me know what you think and do not hesitate to ask for changes or maybe a different strategy. The commit message follows below:

Vertex, index and uniform buffers had a fixed size. With this change,
they can be reallocated when needed and grow to hold more data.

Because Vulkan is async, the existing buffers, their memory and
descriptor sets cannot be deleted or updated right away after allocating
new ones. Instead, the existing buffers need to be kept around for some
time until the device is done using them. That's the purpose of the
"to_be_deleted" fields added to some structures.

Dynamic buffer sizes grow with a factor of 1.5 in each reallocation, as
is common practice[1].

In addition, the common code in R_InitDynamicVertexBuffers,
R_InitDynamicIndexBuffers and R_InitDynamicUniformBuffers has been
abstracted to a single function, and all of them can be called again
when the buffers need to grow in size.

[1] https://stackoverflow.com/questions/2269063/buffer-growth-strategy