### PR TITLE
add type 'float' to alpha to avoid implicit integer

### DIFF
--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -262,7 +262,7 @@ void R_DrawBrushModel_ShowTris(entity_t *e)
 	mplane_t	*pplane;
 	qmodel_t	*clmodel;
 	float color[] = { 1.0f, 1.0f, 1.0f };
-	const alpha = 1.0f;
+	const float alpha = 1.0f;
 
 	if (R_CullModelForEntity(e))
 		return;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -386,7 +386,7 @@ void R_DrawTextureChains_ShowTris(qmodel_t *model, texchain_t chain)
 	msurface_t	*s;
 	texture_t	*t;
 	float color[] = { 1.0f, 1.0f, 1.0f };
-	const alpha = 1.0f;
+	const float alpha = 1.0f;
 
 	for (i = 0; i<model->numtextures; i++)
 	{


### PR DESCRIPTION
Noticed by me when compiling with clang 7 on OpenBSD, also got a report of gcc doing implicit int as well.