### PR TITLE
gl_vidsdl.c: define NO_SDL_VULKAN_TYPEDEFS to workaround build failure

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // gl_vidsdl.c -- SDL vid component
 
+#define NO_SDL_VULKAN_TYPEDEFS
 #include "quakedef.h"
 #include "cfgfile.h"
 #include "bgmusic.h"


### PR DESCRIPTION
I ran into this when building against newest SDK headers:
```
In file included from gl_vidsdl.c:35:0:
../Windows/SDL2/include/SDL_vulkan.h:52:1: error: redefinition of typedef 'VkInstance'
/opt/vk/1.1.121.1/x86_64/include/vulkan/vulkan_core.h:68:1: note: previous declaration of 'VkInstance' was here
../Windows/SDL2/include/SDL_vulkan.h:53:1: error: redefinition of typedef 'VkSurfaceKHR'
/opt/vk/1.1.121.1/x86_64/include/vulkan/vulkan_core.h:4807:1: note: previous declaration of 'VkSurfaceKHR' was here
```

There might be a better solution for this?  If there is, ignore this P/R.