### PR TITLE
Check only for VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT on Windows

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -2067,7 +2067,11 @@ qboolean GL_AcquireNextSwapChainImage(void)
 #endif
 
 	VkResult err = fpAcquireNextImageKHR(vulkan_globals.device, vulkan_swapchain, UINT64_MAX, image_aquired_semaphores[current_command_buffer], VK_NULL_HANDLE, &current_swapchain_buffer);
-	if ((err == VK_ERROR_OUT_OF_DATE_KHR) || (err == VK_ERROR_SURFACE_LOST_KHR) || (err == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT))
+	if ((err == VK_ERROR_OUT_OF_DATE_KHR) || (err == VK_ERROR_SURFACE_LOST_KHR)
+#ifdef _WIN32
+		|| (err == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+#endif
+                )
 	{
 		vid_changed = true;
 		Cbuf_AddText ("vid_restart\n");
@@ -2156,7 +2160,11 @@ void GL_EndRendering (qboolean swapchain_acquired)
 		present_info.waitSemaphoreCount = 1;
 		present_info.pWaitSemaphores = &draw_complete_semaphores[current_command_buffer];
 		err = fpQueuePresentKHR(vulkan_globals.queue, &present_info);
-		if ((err == VK_ERROR_OUT_OF_DATE_KHR) || (err == VK_ERROR_SURFACE_LOST_KHR) || (err == VK_SUBOPTIMAL_KHR) || (err == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)) 
+		if ((err == VK_ERROR_OUT_OF_DATE_KHR) || (err == VK_ERROR_SURFACE_LOST_KHR) || (err == VK_SUBOPTIMAL_KHR)
+#ifdef _WIN32
+			|| (err == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+#endif
+			)
 		{
 			vid_changed = true;
 			Cbuf_AddText ("vid_restart\n");


### PR DESCRIPTION
VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT only exists on Windows so only check for it on Windows. Fixes the build on Linux.