### PR TITLE
Fix warp texture barrier dstAccess

### DIFF
--- a/Quake/gl_warp.c
+++ b/Quake/gl_warp.c
@@ -331,7 +331,7 @@ void R_UpdateWarpTextures (void)
 		image_barrier->sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
 		image_barrier->pNext = NULL;
 		image_barrier->srcAccessMask = 0;
-		image_barrier->dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+		image_barrier->dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
 		image_barrier->oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 		image_barrier->newLayout = VK_IMAGE_LAYOUT_GENERAL;
 		image_barrier->srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;


### PR DESCRIPTION
The image layout transition barrier had the incorrect dstAccessMask,
guarding transfer *read* operations, for mip levels that are the
destination of the mip generation blits. Updated dstAccessMask to
transfer *write*.