### PR TITLE
Increase push constant size to avoid validation errors

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -819,7 +819,7 @@ static void GL_OrthoMatrix(float left, float right, float bottom, float top, flo
 	float ty = (top + bottom) / (top - bottom);
 	float tz = -(f + n) / (f - n);
 
-	float matrix[16];
+	float matrix[21];
 	memset(&matrix, 0, sizeof(matrix));
 
 	// First column
@@ -837,7 +837,11 @@ static void GL_OrthoMatrix(float left, float right, float bottom, float top, flo
 	matrix[3*4 + 2] = tz;
 	matrix[3*4 + 3] = 1.0f;
 
-	vkCmdPushConstants(vulkan_globals.command_buffer, vulkan_globals.basic_pipeline_layout, VK_SHADER_STAGE_ALL_GRAPHICS, 0, 16 * sizeof(float), matrix);
+	// Leave 4 Fog values at 0.0f
+
+	// Alpha
+	matrix[20] = 1.0f;
+	vkCmdPushConstants(vulkan_globals.command_buffer, vulkan_globals.basic_pipeline_layout, VK_SHADER_STAGE_ALL_GRAPHICS, 0, 21 * sizeof(float), matrix);
 }
 
 /*

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -316,7 +316,14 @@ void R_SetupMatrix (void)
 	memcpy(vulkan_globals.view_projection_matrix, vulkan_globals.projection_matrix, 16 * sizeof(float));
 	MatrixMultiply(vulkan_globals.view_projection_matrix, vulkan_globals.view_matrix);
 
-	vkCmdPushConstants(vulkan_globals.command_buffer, vulkan_globals.basic_pipeline_layout, VK_SHADER_STAGE_ALL_GRAPHICS, 0, 16 * sizeof(float), vulkan_globals.view_projection_matrix);
+	float final_push_constants[21];
+	memcpy(final_push_constants, vulkan_globals.view_projection_matrix, 16 * sizeof(float));
+	final_push_constants[16] = 0.0f;  // fog
+	final_push_constants[17] = 0.0f;
+	final_push_constants[18] = 0.0f;
+	final_push_constants[19] = 0.0f;
+	final_push_constants[20] = 1.0f;  // alpha
+	vkCmdPushConstants(vulkan_globals.command_buffer, vulkan_globals.basic_pipeline_layout, VK_SHADER_STAGE_ALL_GRAPHICS, 0, 21 * sizeof(float), final_push_constants);
 }
 
 /*


### PR DESCRIPTION
Per the Vulkan spec, every push constant value must be set prior to a
draw call.

Change the push constants calls in a couple of places to set all 21
float values in the basic_pipeline_layout.