### PR TITLE
Add a package to list necessary to build on Ubuntu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ To compile vkQuake, first install the build dependencies:
 
 Ubuntu:
 ~~~
-apt-get install git make gcc libsdl2-dev libvulkan-dev libvorbis-dev libmad0-dev
+apt-get install git make gcc libsdl2-dev libvulkan-dev libvorbis-dev libmad0-dev libx11-xcb-dev
 ~~~
 
 Arch Linux:


### PR DESCRIPTION
Just needed `libx11-xcb-dev`. Tested working now with a copy of Ubuntu Mate 20.04 -- sounds like Ubuntu updated their packages.