### PR TITLE
Update link to shareware version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ Quake has 4 episodes that are split into 2 files:
 * `pak1.pak`: contains episodes 2-4
 
 These files aren't free to distribute, but `pak0.pak` is sufficient to run the game and it's freely available via the
-[shareware version of Quake](http://bit.ly/2aDMSiz). Use [7-Zip](http://7-zip.org/) or a similar file archiver to extract
+[shareware version of Quake](https://ftp.gwdg.de/pub/misc/ftp.idsoftware.com/idstuff/quake/). Use [7-Zip](http://7-zip.org/) or a similar file archiver to extract
 `quake106.zip/resource.1/ID1/PAK0.PAK`. Alternatively, if you own the game, you can obtain both .pak files from its install media.
 
 Now locate your vkQuake executable, i.e. `vkQuake.exe` on Windows or `vkquake` on Ubuntu. You need to create an `id1` directory


### PR DESCRIPTION
This addresses the issue #241 
While I agree that this is not issue of vkQuake itself, it still would be nice if the link actually pointed to working download location.