### PR TITLE
added path for AUR build

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -21,7 +21,10 @@
             "macFrameworkPath": [
                 "/System/Library/Frameworks",
                 "/Library/Frameworks"
-            ]
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14"
         },
         {
             "name": "Linux",
@@ -54,7 +57,10 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14"
         },
         {
             "name": "Win32",
@@ -74,8 +80,11 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14"
         }
     ],
-    "version": 3
+    "version": 4
 }

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,8 @@ Now locate your vkQuake executable, i.e. `vkQuake.exe` on Windows or `vkquake` o
 next to that and copy `pak0.pak` there, e.g.:
 
 * Windows: `Windows\VisualStudio\Build-vkQuake\x64\Release\id1\pak0.pak`
-* Ubuntu: `Quake\id1\pak0.pak`
+* Ubuntu: `Quake/id1/pak0.pak`
+* Arch/Manjaro: `~/id1/pak0.pak`
 
 Then vkQuake is ready to play.
 


### PR DESCRIPTION
Tested current AUR build, putting pak0 into any of vkQuake folders in /usr/ does not work, so the next best thing is to have id1 folder in home directory.

Additionally, Ubuntu path had slashes the wrong way, so I've corrected it.

For some unknown to me reason, VSC insists on these changes to it's config file, I'm pretty sure these only apply to my case, but don't know how to make VSC not do that.