### PR TITLE
Fix leaks in R_TranslateNewPlayerSkin and TexMgr_ReloadImage.

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -2280,6 +2280,9 @@ void R_TranslateNewPlayerSkin (int playernum)
 
 //upload new image
 	q_snprintf(name, sizeof(name), "player_%i", playernum);
+	if (playertextures[playernum] != NULL) {
+		TexMgr_FreeTexture(playertextures[playernum]);
+	}
 	playertextures[playernum] = TexMgr_LoadImage (currententity->model, name, paliashdr->skinwidth, paliashdr->skinheight,
 		SRC_INDEXED, pixels, paliashdr->gltextures[skinnum][0]->source_file, paliashdr->gltextures[skinnum][0]->source_offset, TEXPREF_PAD | TEXPREF_OVERWRITE);
 

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1376,8 +1376,9 @@ invalid:
 		data = translated;
 	}
 //
-// upload it
+// delete previous texture and upload new one
 //
+	GL_DeleteTexture(glt);
 	switch (glt->source_format)
 	{
 	case SRC_INDEXED:


### PR DESCRIPTION
Prevents leaking textures and Vulkan descriptor sets.

There are at least three ways to reproduce the issue:

1- Spamming the following two console commands in succession (probably the fastest way to reproduce the `TexMgr_ReloadImage` leak):

```
gl_fullbrights 0
gl_fullbrights 1
```

2- Playing Deathmatch with a few [Omicron bots](https://web.archive.org/web/20190319182017/https://mrelusive.com/oldprojects/obots/obots.html) on DM4 (how I first noticed the problem). With 16 players, takes about 11 minutes to crash on my system;

3- In a deathmatch game, spamming the `color` command with different parameters to change the player’s texture (similar to what the [Omicron bots](https://web.archive.org/web/20190319182017/https://mrelusive.com/oldprojects/obots/obots.html) do internally).

All of these will show a steady increase in GPU memory usage, and eventually cause `vkAllocateDescriptorSets` to fail with `VK_ERROR_OUT_OF_POOL_MEMORY` (in the call to `TexMgr_LoadImage32`).
