### PR TITLE
Load external .vis files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ Quake/vkquake
 Quake/vkQuake.exe
 Quake/vkQuake.res
 Windows/VisualStudio/Build-vkQuake/
+Windows/VisualStudio/Id1
 Shaders/Compiled/*spv
 Shaders/bintoc.exe
 Shaders/bintoc.obj
 Windows/VisualStudio/.vs
+/Windows/VisualStudio/history.txt

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1695,7 +1695,8 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 	if (strcmp(COM_FileGetExtension(filename), "pcx") != 0
 		&& strcmp(COM_FileGetExtension(filename), "tga") != 0
 		&& strcmp(COM_FileGetExtension(filename), "lit") != 0
-		&& strcmp(COM_FileGetExtension(filename), "ent") != 0)
+		&& strcmp(COM_FileGetExtension(filename), "ent") != 0
+		&& strcmp(COM_FileGetExtension(filename), "vis") != 0) // 01-24-2021 Dan Abbott - vis file support
 		Con_DPrintf ("FindFile: can't find %s\n", filename);
 	else	Con_DPrintf2("FindFile: can't find %s\n", filename);
 		// Log pcx, tga, lit, ent misses only if (developer.value >= 2)

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1989,54 +1989,11 @@ typedef struct vispatch_s
 // 2001-12-28 .VIS support by Maddes  end
 #define VISPATCH_HEADER_LEN_36 36
 
-///*
-//=================
-//Mod_LoadEntities
-//=================
-//*/
-//void Mod_LoadEntities(lump_t* l)
-//{
-//	char	entfilename[MAX_QPATH];
-//	char* ents;
-//	int		mark;
-//	unsigned int	path_id;
-//
-//	if (!external_ents.value)
-//		goto _load_embedded;
-//
-//	q_strlcpy(entfilename, loadmodel->name, sizeof(entfilename));
-//	COM_StripExtension(entfilename, entfilename, sizeof(entfilename));
-//	q_strlcat(entfilename, ".ent", sizeof(entfilename));
-//	Con_DPrintf2("trying to load %s\n", entfilename);
-//	mark = Hunk_LowMark();
-//	ents = (char*)COM_LoadHunkFile(entfilename, &path_id);
-//	if (ents)
-//	{
-//		// use ent file only from the same gamedir as the map
-//		// itself or from a searchpath with higher priority.
-//		if (path_id < loadmodel->path_id)
-//		{
-//			Hunk_FreeToLowMark(mark);
-//			Con_DPrintf("ignored %s from a gamedir with lower priority\n", entfilename);
-//		}
-//		else
-//		{
-//			loadmodel->entities = ents;
-//			Con_DPrintf("Loaded external entity file %s\n", entfilename);
-//			return;
-//		}
-//	}
-//
-//_load_embedded:
-//	if (!l->filelen)
-//	{
-//		loadmodel->entities = NULL;
-//		return;
-//	}
-//	loadmodel->entities = (char*)Hunk_AllocName(l->filelen, loadname);
-//	memcpy(loadmodel->entities, mod_base + l->fileofs, l->filelen);
-//}
-
+/*
+=================
+Mod_FindVisibilityExternal
+=================
+*/
 static qboolean Mod_FindVisibilityExternal(FILE** filehandle) // 01-24-2021 Dan Abbott - cbool to qboolean
 {
 	char visfilename[MAX_QPATH]; // 01-24-2021 Dan Abbott - MAX_QPATH_64 to MAX_QPATH

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1856,6 +1856,35 @@ void Mod_LoadPlanes (lump_t *l)
 	}
 }
 
+// 01-24-2021 Dan Abbott - vis support from MarkV : start
+// 2001-12-28 .VIS support by Maddes  start
+/*
+=================
+Mod_LoadExternalVisibility
+=================
+*/
+static void Mod_LoadVisibilityExternal(FILE** fhandle)
+{
+	long	filelen = 0;
+
+	// get visibility data length
+	filelen = 0;
+	fread(&filelen, 1, 4, *fhandle);
+	filelen = LittleLong(filelen);
+
+	Con_DPrintf("...%d bytes visibility data\n", (int)filelen); // 01-24-2021 Dan Abbott - Con_DPrintLinef to Con_DPrintf
+
+	// load visibility data
+	if (!filelen)
+	{
+		loadmodel->visdata = NULL;
+		return;
+	}
+	loadmodel->visdata = Hunk_AllocName(filelen, "EXT_VIS");
+	fread(loadmodel->visdata, 1, filelen, *fhandle);
+}
+// 01-24-2021 Dan Abbott - vis support from MarkV : end
+
 /*
 =================
 RadiusFromBounds
@@ -1916,6 +1945,142 @@ void Mod_LoadSubmodels (lump_t *l)
 		Con_DWarning ("%i visleafs exceeds standard limit of 8192.\n", out->visleafs);
 	//johnfitz
 }
+
+// 01-24-2021 Dan Abbott - ganked from Mark V with some changes to work with vkQuake : start
+
+/*
+=================
+Mod_LoadExternalLeafs
+=================
+*/
+static void Mod_LoadLeafsExternal(FILE** fhandle)
+{
+	dsleaf_t* in;
+	long	filelen;
+
+	// get leaf data length
+	filelen = 0;
+	fread(&filelen, 1, 4, *fhandle);
+	filelen = LittleLong(filelen);
+
+	Con_DPrintf("...%d bytes leaf data\n", (int)filelen); // 01-24-2021 Dan Abbott - Con_DPrintLinef to Con_DPrintf
+
+	// load leaf data
+	if (!filelen)
+	{
+		loadmodel->leafs = NULL;
+		loadmodel->numleafs = 0;
+		return;
+	}
+	in = Hunk_AllocName(filelen, "EXT_LEAF");
+	fread(in, 1, filelen, *fhandle);
+
+	Mod_ProcessLeafs_S(in, filelen);
+}
+
+// 2001-12-28 .VIS support by Maddes  start
+#define VISPATCH_MAPNAME_LENGTH	32
+
+typedef struct vispatch_s
+{
+	char	mapname[VISPATCH_MAPNAME_LENGTH];	// Baker: DO NOT CHANGE THIS to MAX_QPATH_64, must be 32
+	int		filelen;		// length of data after VisPatch header (VIS+Leafs)
+} vispatch_t;
+// 2001-12-28 .VIS support by Maddes  end
+#define VISPATCH_HEADER_LEN_36 36
+
+///*
+//=================
+//Mod_LoadEntities
+//=================
+//*/
+//void Mod_LoadEntities(lump_t* l)
+//{
+//	char	entfilename[MAX_QPATH];
+//	char* ents;
+//	int		mark;
+//	unsigned int	path_id;
+//
+//	if (!external_ents.value)
+//		goto _load_embedded;
+//
+//	q_strlcpy(entfilename, loadmodel->name, sizeof(entfilename));
+//	COM_StripExtension(entfilename, entfilename, sizeof(entfilename));
+//	q_strlcat(entfilename, ".ent", sizeof(entfilename));
+//	Con_DPrintf2("trying to load %s\n", entfilename);
+//	mark = Hunk_LowMark();
+//	ents = (char*)COM_LoadHunkFile(entfilename, &path_id);
+//	if (ents)
+//	{
+//		// use ent file only from the same gamedir as the map
+//		// itself or from a searchpath with higher priority.
+//		if (path_id < loadmodel->path_id)
+//		{
+//			Hunk_FreeToLowMark(mark);
+//			Con_DPrintf("ignored %s from a gamedir with lower priority\n", entfilename);
+//		}
+//		else
+//		{
+//			loadmodel->entities = ents;
+//			Con_DPrintf("Loaded external entity file %s\n", entfilename);
+//			return;
+//		}
+//	}
+//
+//_load_embedded:
+//	if (!l->filelen)
+//	{
+//		loadmodel->entities = NULL;
+//		return;
+//	}
+//	loadmodel->entities = (char*)Hunk_AllocName(l->filelen, loadname);
+//	memcpy(loadmodel->entities, mod_base + l->fileofs, l->filelen);
+//}
+
+static qboolean Mod_FindVisibilityExternal(FILE** filehandle) // 01-24-2021 Dan Abbott - cbool to qboolean
+{
+	char visfilename[MAX_QPATH]; // 01-24-2021 Dan Abbott - MAX_QPATH_64 to MAX_QPATH
+	q_snprintf(visfilename, sizeof(visfilename), "maps/%s.vis", loadname); // 01-24-2021 Dan Abbott
+	COM_FOpenFile(visfilename, filehandle, &loadmodel->path_id); //01-24-2021 Dan Abbott - COM_FOpenFile_Limited to COM_FOpenFile
+
+	if (!*filehandle)
+	{
+		Con_DPrintf("Standard vis, %s not found\n", visfilename); // 01-24-2021 Dan Abbott - Con_VerbosePrintLinef to Con_DPrintf
+		
+		return false; // None
+	}
+
+	Con_DPrintf("External .vis found: %s\n", visfilename); // 01-24-2021 Dan Abbott - Con_VerbosePrintLinef to Con_DPrintf
+	{
+		int			i, pos;
+		vispatch_t	header;
+		const char* shortname = COM_SkipPath(loadmodel->name); // start.bsp, e1m1.bsp, etc. // 01-24-2021 Dan Abbott - File_URL_SkipPath to COM_SkipPath
+		pos = 0;
+
+		while ((i = fread(&header, 1, VISPATCH_HEADER_LEN_36, *filehandle))) // i will be length of read, continue while a read
+		{
+			header.filelen = LittleLong(header.filelen);	// Endian correct header.filelen
+			pos += i;										// Advance the length of the break
+
+			if (!q_strcasecmp(header.mapname, shortname)) // 01-24-2021 Dan Abbott - strcasecmp to q_strcasecmp
+				break;
+
+			pos += header.filelen;							// Advance the length of the filelength
+			fseek(*filehandle, pos, SEEK_SET);
+		}
+
+		if (i != VISPATCH_HEADER_LEN_36)
+		{
+			FS_fclose(*filehandle);
+			return false;
+		}
+	}
+
+	return true;
+
+}
+// 2001-12-28 .VIS support by Maddes  end
+// 01-24-2021 Dan Abbott - ganked from Mark V with some changes to work with vkQuake : end
 
 /*
 =================
@@ -1982,6 +2147,8 @@ void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	dmodel_t 	*bm;
 	float		radius; //johnfitz
 
+	extern cvar_t external_vis; // 01-24-2021 Dan Abbott
+
 	loadmodel->type = mod_brush;
 
 	header = (dheader_t *)buffer;
@@ -2021,8 +2188,49 @@ void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	Mod_LoadTexinfo (&header->lumps[LUMP_TEXINFO]);
 	Mod_LoadFaces (&header->lumps[LUMP_FACES], bsp2);
 	Mod_LoadMarksurfaces (&header->lumps[LUMP_MARKSURFACES], bsp2);
-	Mod_LoadVisibility (&header->lumps[LUMP_VISIBILITY]);
-	Mod_LoadLeafs (&header->lumps[LUMP_LEAFS], bsp2);
+
+	// 01-24-2021 Dan Abbott - use Mark V vis file loading : start
+	do
+	{
+		// 2001-12-28 .VIS support by Maddes  start
+		FILE* visfhandle;	// Baker: try to localize this var
+
+		loadmodel->visdata = NULL;
+		loadmodel->leafs = NULL;
+		loadmodel->numleafs = 0;
+		if ((sv.modelname[0] && !q_strcasecmp(loadname, sv.name)) && external_vis.value) // 01-24-2021 Dan Abbott
+		{
+			Con_DPrintf("trying to open external vis file\n"); // 01-24-2021 Dan Abbott - Con_DPrintLinef to Con_DPrintf
+
+			if (Mod_FindVisibilityExternal(&visfhandle /* We should be passing infos here &visfilehandle*/))
+			{
+				// File exists, valid and open
+				Con_DPrintf("found valid external .vis file for map\n"); // 01-24-2021 Dan Abbott - Con_DPrintLinef to Con_DPrintf
+				Mod_LoadVisibilityExternal(&visfhandle);
+				Mod_LoadLeafsExternal(&visfhandle);
+
+				FS_fclose(&visfhandle); // 01-24-2021 Dan Abbott
+
+				if (loadmodel->visdata && loadmodel->leafs && loadmodel->numleafs)
+				{
+					break; // skip standard vis
+				}
+				Con_Printf("External VIS data are invalid! Doing standard vis.\n"); // 01-24-2021 Dan Abbott - Con_PrintLinef to Con_Printf
+			}
+		}
+		// Extern vis didn't exist or was invalid ..
+
+		//
+		// standard vis
+		//
+		Mod_LoadVisibility(&header->lumps[LUMP_VISIBILITY]);
+		Mod_LoadLeafs(&header->lumps[LUMP_LEAFS], bsp2);
+	} while (0);
+
+	// 01-24-2021 Dan Abbott - use Mark V vis file loading : end
+
+	// Mod_LoadVisibility (&header->lumps[LUMP_VISIBILITY]); // 01-24-2021 Dan Abbott
+	// Mod_LoadLeafs (&header->lumps[LUMP_LEAFS], bsp2); // 01-24-2021 Dan Abbott
 	Mod_LoadNodes (&header->lumps[LUMP_NODES], bsp2);
 	Mod_LoadClipnodes (&header->lumps[LUMP_CLIPNODES], bsp2);
 	Mod_LoadEntities (&header->lumps[LUMP_ENTITIES]);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -68,7 +68,7 @@ cvar_t	r_pos = {"r_pos","0",CVAR_NONE};
 cvar_t	r_wateralpha = {"r_wateralpha","1",CVAR_ARCHIVE};
 cvar_t	r_dynamic = {"r_dynamic","1",CVAR_ARCHIVE};
 cvar_t	r_novis = {"r_novis","0",CVAR_ARCHIVE};
-cvar_t	external_vis = { "external_vis", "1", CVAR_ARCHIVE }; // 01-24-2021 Dan Abbott
+cvar_t	external_vis = {"external_vis","1",CVAR_ARCHIVE}; // 01-24-2021 Dan Abbott
 
 cvar_t	gl_finish = {"gl_finish","0",CVAR_NONE};
 cvar_t	gl_polyblend = {"gl_polyblend","1",CVAR_NONE};

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -68,6 +68,7 @@ cvar_t	r_pos = {"r_pos","0",CVAR_NONE};
 cvar_t	r_wateralpha = {"r_wateralpha","1",CVAR_ARCHIVE};
 cvar_t	r_dynamic = {"r_dynamic","1",CVAR_ARCHIVE};
 cvar_t	r_novis = {"r_novis","0",CVAR_ARCHIVE};
+cvar_t	external_vis = { "external_vis", "1", CVAR_ARCHIVE }; // 01-24-2021 Dan Abbott
 
 cvar_t	gl_finish = {"gl_finish","0",CVAR_NONE};
 cvar_t	gl_polyblend = {"gl_polyblend","1",CVAR_NONE};

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -43,6 +43,8 @@ extern cvar_t r_nolerp_list;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 
+extern cvar_t external_vis; // 01-24-2021 Dan Abbott
+
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
 
 vulkanglobals_t vulkan_globals;
@@ -2189,6 +2191,7 @@ void R_Init (void)
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
 	Cvar_RegisterVariable (&r_dynamic);
 	Cvar_RegisterVariable (&r_novis);
+	Cvar_RegisterVariable(&external_vis); // 01-24-2021 Dan Abbott
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -2191,7 +2191,7 @@ void R_Init (void)
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
 	Cvar_RegisterVariable (&r_dynamic);
 	Cvar_RegisterVariable (&r_novis);
-	Cvar_RegisterVariable(&external_vis); // 01-24-2021 Dan Abbott
+	Cvar_RegisterVariable (&external_vis); // 01-24-2021 Dan Abbott
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
 


### PR DESCRIPTION
Resolves #242 

Loads .vis files from /maps, functionally identical to Mark V Quake.

Also contains two changes to .gitignore to avoid committing id1 from where I'm using it, and my console history.