### PR TITLE
Restore misssing gl_polyblend CVAR register

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -2194,7 +2194,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&external_vis); // 01-24-2021 Dan Abbott
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
-
+	Cvar_RegisterVariable (&gl_polyblend);
 	Cvar_RegisterVariable (&gl_nocolors);
 
 	//johnfitz -- new cvars


### PR DESCRIPTION
This fixes #289 and other gl_polyblend related renders probably. 

During the last CVAR cleanup https://github.com/Novum/vkQuake/commit/6366346a38b0345acd1fd02cc3e5a047d71f8990 it (likely) got removed erroneously.