### PR TITLE
Add r_lightmap support

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -65,6 +65,7 @@ cvar_t	r_drawentities = {"r_drawentities","1",CVAR_NONE};
 cvar_t	r_drawviewmodel = {"r_drawviewmodel","1",CVAR_NONE};
 cvar_t	r_speeds = {"r_speeds","0",CVAR_NONE};
 cvar_t	r_pos = {"r_pos","0",CVAR_NONE};
+cvar_t	r_lightmap = {"r_lightmap","0",CVAR_NONE};
 cvar_t	r_wateralpha = {"r_wateralpha","1",CVAR_ARCHIVE};
 cvar_t	r_dynamic = {"r_dynamic","1",CVAR_ARCHIVE};
 cvar_t	r_novis = {"r_novis","0",CVAR_ARCHIVE};

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -2183,6 +2183,7 @@ void R_Init (void)
 	Cmd_AddCommand ("pointfile", R_ReadPointFile_f);
 	Cmd_AddCommand ("vkmemstats", R_VulkanMemStats_f);
 
+	Cvar_RegisterVariable (&r_lightmap);
 	Cvar_RegisterVariable (&r_drawentities);
 	Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_wateralpha);

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -712,13 +712,17 @@ FIXME: eliminate cracks by adding an extra vert on tjuncs
 void Sky_DrawSkyBox (void)
 {
 	int		i, j;
+	qboolean show_lightmap = (cl.maxclients == 1 && r_lightmap.value);
 
 	for (i=0 ; i<6 ; i++)
 	{
 		if (skymins[0][i] >= skymaxs[0][i] || skymins[1][i] >= skymaxs[1][i])
 			continue;
 
-		vkCmdBindDescriptorSets(vulkan_globals.command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vulkan_globals.basic_pipeline_layout.handle, 0, 1, &skybox_textures[skytexorder[i]]->descriptor_set, 0, NULL);
+		gltexture_t * gl_texture = skybox_textures[skytexorder[i]];
+		if (show_lightmap)
+			gl_texture = greytexture;
+		vkCmdBindDescriptorSets(vulkan_globals.command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vulkan_globals.basic_pipeline_layout.handle, 0, 1, &gl_texture->descriptor_set, 0, NULL);
 
 		VkBuffer buffer;
 		VkDeviceSize buffer_offset;
@@ -836,10 +840,13 @@ void Sky_DrawFaceQuad (glpoly_t *p, float alpha)
 {
 	float	*v;
 	int		i;
+	qboolean show_lightmap = (cl.maxclients == 1 && r_lightmap.value);
 
 	R_BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, vulkan_globals.sky_layer_pipeline);
 
 	VkDescriptorSet descriptor_sets[2] = { solidskytexture->descriptor_set, alphaskytexture->descriptor_set };
+	if (show_lightmap)
+		descriptor_sets[0] = descriptor_sets[1] = greytexture->descriptor_set;
 	vkCmdBindDescriptorSets(vulkan_globals.command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vulkan_globals.sky_layer_pipeline.layout.handle, 0, 2, descriptor_sets, 0, NULL);
 
 	VkBuffer vertex_buffer;

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -35,7 +35,7 @@ extern cvar_t vid_anisotropic;
 #define	MAX_MIPS 16
 static int numgltextures;
 static gltexture_t	*active_gltextures, *free_gltextures;
-gltexture_t		*notexture, *nulltexture;
+gltexture_t		*notexture, *nulltexture, *greytexture;
 
 unsigned int d_8to24table[256];
 unsigned int d_8to24table_fbright[256];
@@ -419,6 +419,7 @@ void TexMgr_Init (void)
 	int i;
 	static byte notexture_data[16] = {159,91,83,255,0,0,0,255,0,0,0,255,159,91,83,255}; //black and pink checker
 	static byte nulltexture_data[16] = {127,191,255,255,0,0,0,255,0,0,0,255,127,191,255,255}; //black and blue checker
+	static byte greytexture_data[16] = {127,127,127,255,127,127,127,255,127,127,127,255,127,127,127,255}; //50% grey
 	extern texture_t *r_notexture_mip, *r_notexture_mip2;
 
 	// init texture list
@@ -439,6 +440,7 @@ void TexMgr_Init (void)
 	// load notexture images
 	notexture = TexMgr_LoadImage (NULL, "notexture", 2, 2, SRC_RGBA, notexture_data, "", (src_offset_t)notexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP);
 	nulltexture = TexMgr_LoadImage (NULL, "nulltexture", 2, 2, SRC_RGBA, nulltexture_data, "", (src_offset_t)nulltexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP);
+	greytexture = TexMgr_LoadImage (NULL, "greytexture", 2, 2, SRC_RGBA, greytexture_data, "", (src_offset_t)greytexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP);
 
 	//have to assign these here becuase Mod_Init is called before TexMgr_Init
 	r_notexture_mip->gltexture = r_notexture_mip2->gltexture = notexture;

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -77,6 +77,7 @@ typedef struct gltexture_s {
 
 extern gltexture_t *notexture;
 extern gltexture_t *nulltexture;
+extern gltexture_t *greytexture;
 
 extern unsigned int d_8to24table[256];
 extern unsigned int d_8to24table_fbright[256];

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -263,6 +263,7 @@ extern	cvar_t	r_drawworld;
 extern	cvar_t	r_drawviewmodel;
 extern	cvar_t	r_speeds;
 extern	cvar_t	r_pos;
+extern	cvar_t	r_lightmap;
 extern	cvar_t	r_waterwarp;
 extern	cvar_t	r_wateralpha;
 extern	cvar_t	r_lavaalpha;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -115,6 +115,12 @@ static void GL_DrawAliasFrame (aliashdr_t *paliashdr, lerpdata_t lerpdata, gltex
 		blend = 0;
 	}
 
+	if (cl.maxclients == 1 && r_lightmap.value)
+	{
+		tx = greytexture;
+		fb = NULL;
+	}
+
 	vulkan_pipeline_t pipeline = alphatest ? vulkan_globals.alias_alphatest_pipeline : ((entalpha < 1.0f) ? vulkan_globals.alias_blend_pipeline : vulkan_globals.alias_pipeline);
 	R_BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 


### PR DESCRIPTION
Added back r_lightmap support (issue #298) by replacing the base texture with a built-in 50% grey one when rendering the world, water, sky and alias models.