### PR TITLE
minor warning fixes:

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1410,7 +1410,7 @@ static void GL_DeleteTexture (gltexture_t *texture)
 	int garbage_index;
 	texture_garbage_t * garbage;
 
-	if (texture->image_view == NULL)
+	if (!texture->image_view)
 		return;
 
 	if (in_update_screen)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -428,6 +428,14 @@ void R_CreatePipelineLayouts();
 void R_CreatePipelines();
 void R_DestroyPipelines();
 
+#if defined(_MSC_VER)
+#include <malloc.h>
+#define alloca _alloca
+#endif
+#if defined(__GNUC__) && !defined(alloca)
+#define alloca __builtin_alloca
+#endif
+
 static inline void R_BindPipeline(VkPipelineBindPoint bind_point, vulkan_pipeline_t pipeline)
 {
 	assert(pipeline.handle != VK_NULL_HANDLE);


### PR DESCRIPTION
- fix comparison between integer and pointer in gl_texmgr.c in 32 bits:
  VkImageView is an uint64_t, not a pointer in 32 bits.
- make sure alloca() is defined in glquake.h for R_BindPipeline().