### PR TITLE
Fix startup crash ("failed to find vkSetDebugUtilsObjectNameEXT") in debug builds

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -176,6 +176,11 @@ static uint32_t current_swapchain_buffer;
 	if (fp##entrypoint == NULL) Sys_Error("vkGetInstanceProcAddr failed to find vk" #entrypoint); \
 }
 
+#define GET_GLOBAL_INSTANCE_PROC_ADDR(_var, entrypoint) { \
+	vulkan_globals. _var = (PFN_##entrypoint)fpGetInstanceProcAddr(vulkan_instance, #entrypoint); \
+	if (vulkan_globals. _var == NULL) Sys_Error("vkGetDeviceProcAddr failed to find " #entrypoint); \
+}
+
 #define GET_DEVICE_PROC_ADDR(entrypoint) { \
 	fp##entrypoint = (PFN_vk##entrypoint)fpGetDeviceProcAddr(vulkan_globals.device, "vk" #entrypoint); \
 	if (fp##entrypoint == NULL) Sys_Error("vkGetDeviceProcAddr failed to find vk" #entrypoint); \
@@ -952,9 +957,9 @@ static void GL_InitDevice( void )
 #ifdef _DEBUG
 	if (vulkan_globals.debug_utils)
 	{
-		GET_DEVICE_PROC_ADDR(SetDebugUtilsObjectNameEXT);
-		GET_GLOBAL_DEVICE_PROC_ADDR(vk_cmd_begin_debug_utils_label, vkCmdBeginDebugUtilsLabelEXT);
-		GET_GLOBAL_DEVICE_PROC_ADDR(vk_cmd_end_debug_utils_label, vkCmdEndDebugUtilsLabelEXT);
+		GET_INSTANCE_PROC_ADDR(SetDebugUtilsObjectNameEXT);
+		GET_GLOBAL_INSTANCE_PROC_ADDR(vk_cmd_begin_debug_utils_label, vkCmdBeginDebugUtilsLabelEXT);
+		GET_GLOBAL_INSTANCE_PROC_ADDR(vk_cmd_end_debug_utils_label, vkCmdEndDebugUtilsLabelEXT);
 	}
 #endif
 


### PR DESCRIPTION
When I tried to run a debug build on MacOS, it would crash on startup with the error "QUAKE ERROR: vkGetDeviceProcAddr failed to find vkSetDebugUtilsObjectNameEXT". I [found a post with an explanation and a fix for the issue](https://forums.developer.nvidia.com/t/vksetdebugutilsobjectnameext-causes-a-crash-when-attempting-to-set-a-name-for-vkphysicaldevice/79517/6) so I followed its instructions and the issue appeared fixed. It seems like the previous code only worked on some platforms because of [some workarounds in specific platforms](https://github.com/KhronosGroup/Vulkan-Loader/issues/116#issuecomment-539176985). It seems like this change makes it work fully following the standards now.