### PR TITLE
Build config improvements for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ AppImage/vkquake*.AppImage
 .settings
 .project
 .cproject
+.DS_Store

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,6 +5,7 @@
             "includePath": [
                 "/usr/include",
                 "/usr/local/include",
+                "/opt/homebrew/include",
                 "${workspaceRoot}"
             ],
             "defines": [],
@@ -13,6 +14,7 @@
                 "path": [
                     "/usr/include",
                     "/usr/local/include",
+                    "/opt/homebrew/include",
                     "${workspaceRoot}"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
@@ -21,7 +23,10 @@
             "macFrameworkPath": [
                 "/System/Library/Frameworks",
                 "/Library/Frameworks"
-            ]
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "gnu99",
+            "cppStandard": "c++98"
         },
         {
             "name": "Linux",
@@ -54,7 +59,9 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "cStandard": "gnu99",
+            "cppStandard": "c++98"
         },
         {
             "name": "Win32",
@@ -74,8 +81,10 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "cStandard": "gnu99",
+            "cppStandard": "c++98"
         }
     ],
-    "version": 3
+    "version": 4
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,22 +6,14 @@
     "configurations": [
         {
             "name": "vkquake",
-            "type": "cppdbg",
+            // The CodeLLDB extension is required for this.
+            // https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb
+            "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/Quake/vkquake",
             "args": [ "-basedir", "/home/axel/Quake" ],
-            "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
-            "environment": [ { "name": "XDG_RUNTIME_DIR", "value": "/run/user/1000" } ],
-            "externalConsole": true,
-            "MIMode": "lldb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                }
-            ]
+            "preLaunchTask": "debug"
         }
     ]
 }

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -152,6 +152,10 @@ ifneq ($(HOST_OS),darwin)
 COMMON_LIBS+= -lvulkan
 CFLAGS+= -DLINUX
 else
+ifeq ($(shell test -d /opt/homebrew && echo true),true)
+COMMON_LIBS+= -L/opt/homebrew/lib
+CFLAGS+= -I/opt/homebrew/include
+endif
 COMMON_LIBS+= -lMoltenVK
 endif
 


### PR DESCRIPTION
- The MacOS instructions in the readme don't work as-is on newer M1 ARM Macs because homebrew now installs into /opt/homebrew instead of /usr/local and clang doesn't know to look there by default. Since installing the libraries through homebrew is the readme-recommended setup and is what most Mac devs are probably doing, I think it's worth supporting out of the box like this. It won't have any downsides to people not using homebrew, or people using homebrew but not for these libraries.
- The VSCode launch config was changed to start and debug vkquake with the CodeLLDB extension [because the VSCode default doesn't support debugging on M1 Macs currently](https://github.com/microsoft/vscode-cpptools/issues/6779#issuecomment-854675319). I assume that will work well for other platforms too but if people had any attachment to the old setup then this launch task could be moved into a new "vkquake (Mac)" launch task instead.