### PR TITLE
Reset pointers to sky textures on map unload/game change

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2563,6 +2563,7 @@ static void COM_Game_f (void)
 		//clear out and reload appropriate data
 		Cache_Flush ();
 		Mod_ResetAll();
+		Sky_ClearAll();
 		if (!isDedicated)
 		{
 			TexMgr_NewGame ();

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -228,7 +228,6 @@ void Mod_ClearAll (void)
 			mod->needload = true;
 			TexMgr_FreeTexturesForOwner (mod); //johnfitz
 		}
-	Sky_ClearAll();
 }
 
 void Mod_ResetAll (void)
@@ -246,7 +245,6 @@ void Mod_ResetAll (void)
 		memset(mod, 0, sizeof(qmodel_t));
 	}
 	mod_numknown = 0;
-	Sky_ClearAll();
 }
 
 /*

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -228,6 +228,7 @@ void Mod_ClearAll (void)
 			mod->needload = true;
 			TexMgr_FreeTexturesForOwner (mod); //johnfitz
 		}
+	Sky_ClearAll();
 }
 
 void Mod_ResetAll (void)
@@ -245,6 +246,7 @@ void Mod_ResetAll (void)
 		memset(mod, 0, sizeof(qmodel_t));
 	}
 	mod_numknown = 0;
+	Sky_ClearAll();
 }
 
 /*

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -219,6 +219,24 @@ void Sky_LoadSkyBox (const char *name)
 
 /*
 =================
+Sky_ClearAll
+
+Called on map unload/game change to avoid keeping pointers to freed data
+=================
+*/
+void Sky_ClearAll (void)
+{
+	int i;
+
+	skybox_name[0] = 0;
+	for (i=0; i<6; i++)
+		skybox_textures[i] = NULL;
+	solidskytexture = NULL;
+	alphaskytexture = NULL;
+}
+
+/*
+=================
 Sky_NewMap
 =================
 */
@@ -226,14 +244,7 @@ void Sky_NewMap (void)
 {
 	char	key[128], value[4096];
 	const char	*data;
-	int		i;
 
-	//
-	// initially no sky
-	//
-	skybox_name[0] = 0;
-	for (i=0; i<6; i++)
-		skybox_textures[i] = NULL;
 	skyfog = r_skyfog.value;
 
 	//

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -423,6 +423,7 @@ void DrawGLPoly (glpoly_t *p, float color[3], float alpha);
 void GL_MakeAliasModelDisplayLists (qmodel_t *m, aliashdr_t *hdr);
 
 void Sky_Init (void);
+void Sky_ClearAll (void);
 void Sky_DrawSky (void);
 void Sky_NewMap (void);
 void Sky_LoadTexture (texture_t *mt);

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -594,6 +594,7 @@ void Host_ClearMemory (void)
 
 	Con_DPrintf ("Clearing memory\n");
 	Mod_ClearAll ();
+	Sky_ClearAll();
 /* host_hunklevel MUST be set at this point */
 	Hunk_FreeToLowMark (host_hunklevel);
 	cls.signon = 0;


### PR DESCRIPTION
After loading a map with a sky (e.g. start), switching to a skyless one (e.g. warp_co from #319) leads to a crash in `Sky_DrawSkyLayers` due to stale pointers to the solid/alpha sky textures (freed in `TexMgr_FreeTexturesForOwner`, called by `Mod_ClearAll`).

The same scenario doesn't crash QS because QS doesn't try to use the textures until after the [bounds check](https://sourceforge.net/p/quakespasm/quakespasm/ci/3fc32bf7fe93d40d63bd0f48df67467d7f8efd25/tree/Quake/gl_sky.c#l966) (which in this case always fails), whereas vkQuake first binds the pipeline and the (stale) texture descriptors and then proceeds to the bound check and the actual drawing:
https://github.com/Novum/vkQuake/blob/5bf976a4afc468b1873316725132e1c7597f15eb/Quake/gl_sky.c#L909-L916
A minimal solution would have been to delay the bindings until they are first needed, or maybe move them to `Sky_DrawFace`, but clearing the pointers on map unload/game change seems more robust that relying on just the bounds check.

@sezero can you take a look at this, please? I'm hoping it could also be integrated into QS (even if not strictly necessary) to avoid further divergence.