### PR TITLE
Add support for the 2021 re-release

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1923,7 +1923,7 @@ void CL_ParseServerMessage (void)
 			cl.completed_time = cl.time;
 			vid.recalc_refdef = true;	// go to full screen
 			//johnfitz -- log centerprints to console
-			str = LOC_GetString (MSG_ReadString ());
+			str = MSG_ReadString ();
 			SCR_CenterPrint (str);
 			Con_LogCenterPrint (str);
 			//johnfitz
@@ -1934,7 +1934,7 @@ void CL_ParseServerMessage (void)
 			cl.completed_time = cl.time;
 			vid.recalc_refdef = true;	// go to full screen
 			//johnfitz -- log centerprints to console
-			str = LOC_GetString (MSG_ReadString ());
+			str = MSG_ReadString ();
 			SCR_CenterPrint (str);
 			Con_LogCenterPrint (str);
 			//johnfitz

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1923,7 +1923,7 @@ void CL_ParseServerMessage (void)
 			cl.completed_time = cl.time;
 			vid.recalc_refdef = true;	// go to full screen
 			//johnfitz -- log centerprints to console
-			str = MSG_ReadString ();
+			str = LOC_GetString (MSG_ReadString ());
 			SCR_CenterPrint (str);
 			Con_LogCenterPrint (str);
 			//johnfitz
@@ -1934,7 +1934,7 @@ void CL_ParseServerMessage (void)
 			cl.completed_time = cl.time;
 			vid.recalc_refdef = true;	// go to full screen
 			//johnfitz -- log centerprints to console
-			str = MSG_ReadString ();
+			str = LOC_GetString (MSG_ReadString ());
 			SCR_CenterPrint (str);
 			Con_LogCenterPrint (str);
 			//johnfitz

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2923,7 +2923,7 @@ fail:		if (fp) fclose(fp);
 	cursor = localization.text;
 
 	// skip BOM
-	if (cursor[0] == 0xEF && cursor[1] == 0xBB && cursor[2] == 0xB)
+	if ((unsigned char)(cursor[0]) == 0xEF && (unsigned char)(cursor[1]) == 0xBB && cursor[2] == 0xB)
 		cursor += 3;
 
 	lineno = 0;
@@ -2957,6 +2957,7 @@ fail:		if (fp) fclose(fp);
 			char *key_end = equals;
 			qboolean leading_quote;
 			qboolean trailing_quote;
+			locentry_t *entry;
 			char *value_src;
 			char *value_dst;
 			char *value;
@@ -3033,7 +3034,7 @@ fail:		if (fp) fclose(fp);
 				localization.entries = (locentry_t*) realloc(localization.entries, sizeof(*localization.entries) * localization.maxnumentries);
 			}
 
-			locentry_t *entry = &localization.entries[localization.numentries++];
+			entry = &localization.entries[localization.numentries++];
 			entry->key = line;
 			entry->value = value;
 		}

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2931,7 +2931,12 @@ void LOC_LoadFile (const char *path)
 			cursor++;
 		}
 
-		if (equals)
+		if (line[0] == '/')
+		{
+			if (line[1] != '/')
+				Con_Printf("LOC_LoadFile: malformed comment on line %d\n", lineno);
+		}
+		else if (equals)
 		{
 			char *key_end = equals;
 			// trim whitespace before equals sign

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -3065,7 +3065,7 @@ LOC_Init
 */
 void LOC_Init()
 {
-	LOC_LoadFile("loc_english.txt");
+	LOC_LoadFile("localization/loc_english.txt");
 }
 
 /*

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -3025,7 +3025,7 @@ void LOC_LoadFile (const char *path)
 	localization.numindices = localization.numentries * 2; // 50% load factor
 	if (localization.numindices == 0)
 	{
-		Con_DPrintf("No localized strings in file '%s'\n", localization.numentries, path);
+		Con_DPrintf("No localized strings in file '%s'\n", path);
 		return;
 	}
 

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2900,26 +2900,23 @@ void LOC_LoadFile (const char *file)
 	localization.numentries = 0;
 	localization.numindices = 0;
 
-	if (!file || !*file) return;
+	if (!file || !*file)
+		return;
 
 	q_snprintf(path, sizeof(path), "%s/%s", com_basedir, file);
 	fp = fopen(path, "r");
 	if (!fp) goto fail;
-
 	fseek(fp, 0, SEEK_END);
 	i = ftell(fp);
 	if (i <= 0) goto fail;
-
-	localization.text = (char *) calloc(1, i + 1);
+	localization.text = (char *) calloc(1, i+1);
 	if (!localization.text)
 	{
 fail:		if (fp) fclose(fp);
 		Con_DPrintf("Couldn't load localization file '%s'\n", file);
 		return;
 	}
-
 	fseek(fp, 0, SEEK_SET);
-	localization.text[i] = 0;
 	fread(localization.text, 1, i, fp);
 	fclose(fp);
 

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2903,6 +2903,8 @@ void LOC_LoadFile (const char *file)
 	if (!file || !*file)
 		return;
 
+	Con_Printf("\nLanguage initialization\n");
+
 	q_snprintf(path, sizeof(path), "%s/%s", com_basedir, file);
 	fp = fopen(path, "r");
 	if (!fp) goto fail;
@@ -2913,7 +2915,7 @@ void LOC_LoadFile (const char *file)
 	if (!localization.text)
 	{
 fail:		if (fp) fclose(fp);
-		Con_DPrintf("Couldn't load localization file '%s'\n", file);
+		Con_Printf("Couldn't load '%s'\nfrom '%s'\n", file, com_basedir);
 		return;
 	}
 	fseek(fp, 0, SEEK_SET);
@@ -2950,7 +2952,7 @@ fail:		if (fp) fclose(fp);
 		if (line[0] == '/')
 		{
 			if (line[1] != '/')
-				Con_Printf("LOC_LoadFile: malformed comment on line %d\n", lineno);
+				Con_DPrintf("LOC_LoadFile: malformed comment on line %d\n", lineno);
 		}
 		else if (equals)
 		{
@@ -3048,7 +3050,7 @@ fail:		if (fp) fclose(fp);
 	localization.numindices = localization.numentries * 2; // 50% load factor
 	if (localization.numindices == 0)
 	{
-		Con_DPrintf("No localized strings in file '%s'\n", path);
+		Con_Printf("No localized strings in file '%s'\n", file);
 		return;
 	}
 
@@ -3073,11 +3075,11 @@ fail:		if (fp) fclose(fp);
 				pos = 0;
 
 			if (pos == end)
-				Sys_Error("COM_LoadLocalization failed");
+				Sys_Error("LOC_LoadFile failed");
 		}
 	}
 
-	Con_DPrintf("Loaded %d localized strings from '%s'\n", localization.numentries, path);
+	Con_Printf("Loaded %d strings from '%s'\n", localization.numentries, file);
 }
 
 /*

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -208,8 +208,9 @@ char *va (const char *format, ...) FUNC_PRINTF(1,2);
 unsigned COM_HashString (const char *str);
 
 void LOC_Init (void);
-const char* LOC_GetRawString (const char* key);
-const char* LOC_GetString (const char* key);
+const char* LOC_GetRawString (const char *key);
+const char* LOC_GetString (const char *key);
+qboolean LOC_HasPlaceholders (const char *str);
 size_t LOC_Format (const char *format, const char* (*getarg) (int index, void* userdata), void* userdata, char* out, size_t len);
 
 //============================================================================

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -207,11 +207,13 @@ char *va (const char *format, ...) FUNC_PRINTF(1,2);
 
 unsigned COM_HashString (const char *str);
 
+// localization support for 2021 rerelease version:
 void LOC_Init (void);
+void LOC_Shutdown (void);
 const char* LOC_GetRawString (const char *key);
 const char* LOC_GetString (const char *key);
 qboolean LOC_HasPlaceholders (const char *str);
-size_t LOC_Format (const char *format, const char* (*getarg) (int index, void* userdata), void* userdata, char* out, size_t len);
+size_t LOC_Format (const char *format, const char* (*getarg_fn)(int idx, void* userdata), void* userdata, char* out, size_t len);
 
 //============================================================================
 

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -205,6 +205,12 @@ void COM_CreatePath (char *path);
 char *va (const char *format, ...) FUNC_PRINTF(1,2);
 // does a varargs printf into a temp buffer
 
+unsigned COM_HashString (const char *str);
+
+void LOC_Init ();
+const char* LOC_GetRawString (const char* key);
+const char* LOC_GetString (const char* key);
+size_t LOC_Format (const char *format, const char* (*getarg) (int index, void* userdata), void* userdata, char* out, size_t len);
 
 //============================================================================
 

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -207,7 +207,7 @@ char *va (const char *format, ...) FUNC_PRINTF(1,2);
 
 unsigned COM_HashString (const char *str);
 
-void LOC_Init ();
+void LOC_Init (void);
 const char* LOC_GetRawString (const char* key);
 const char* LOC_GetString (const char* key);
 size_t LOC_Format (const char *format, const char* (*getarg) (int index, void* userdata), void* userdata, char* out, size_t len);

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1035,6 +1035,8 @@ void Host_Init (void)
 		CL_Init ();
 	}
 
+	LOC_Init ();
+
 	Hunk_AllocName (0, "-HOST_HUNKLEVEL-");
 	host_hunklevel = Hunk_LowMark ();
 

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1035,7 +1035,7 @@ void Host_Init (void)
 		CL_Init ();
 	}
 
-	LOC_Init ();
+	LOC_Init (); // for 2021 rerelease support.
 
 	Hunk_AllocName (0, "-HOST_HUNKLEVEL-");
 	host_hunklevel = Hunk_LowMark ();
@@ -1100,5 +1100,7 @@ void Host_Shutdown(void)
 	}
 
 	LOG_Close ();
+
+	LOC_Shutdown ();
 }
 

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -42,20 +42,20 @@ char *PR_GetTempString (void)
 ===============================================================================
 */
 
-static const char* PF_GetStringArg(int index, void* userdata)
+static const char* PF_GetStringArg(int idx, void* userdata)
 {
 	if (userdata)
-		index += *(int*)userdata;
-	if (index < 0 || index >= qcvm->argc)
+		idx += *(int*)userdata;
+	if (idx < 0 || idx >= qcvm->argc)
 		return "";
-	return G_STRING((OFS_PARM0 + index * 3));
+	return LOC_GetString(G_STRING(OFS_PARM0 + idx * 3));
 }
 
 char *PF_VarString (int	first)
 {
 	int		i;
 	static char out[1024];
-	const char *localized;
+	const char *format;
 	size_t s;
 
 	out[0] = 0;
@@ -64,17 +64,17 @@ char *PF_VarString (int	first)
 	if (first >= qcvm->argc)
 		return out;
 
-	localized = LOC_GetRawString(G_STRING((OFS_PARM0 + first * 3)));
-	if (localized)
+	format = LOC_GetString(G_STRING((OFS_PARM0 + first * 3)));
+	if (LOC_HasPlaceholders(format))
 	{
 		int offset = first + 1;
-		s = LOC_Format(localized, PF_GetStringArg, &offset, out, sizeof(out));
+		s = LOC_Format(format, PF_GetStringArg, &offset, out, sizeof(out));
 	}
 	else
 	{
 		for (i = first; i < qcvm->argc; i++)
 		{
-			s = q_strlcat(out, G_STRING((OFS_PARM0+i*3)), sizeof(out));
+			s = q_strlcat(out, LOC_GetString(G_STRING(OFS_PARM0+i*3)), sizeof(out));
 			if (s >= sizeof(out))
 			{
 				Con_Warning("PF_VarString: overflow (string truncated)\n");

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -55,14 +55,16 @@ char *PF_VarString (int	first)
 {
 	int		i;
 	static char out[1024];
+	const char *localized;
 	size_t s;
 
 	out[0] = 0;
 	s = 0;
+
 	if (first >= qcvm->argc)
 		return out;
 
-	const char *localized = LOC_GetRawString(G_STRING((OFS_PARM0 + first * 3)));
+	localized = LOC_GetRawString(G_STRING((OFS_PARM0 + first * 3)));
 	if (localized)
 	{
 		int offset = first + 1;

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -1617,7 +1617,7 @@ static void PF_sv_WriteCoord (void)
 
 static void PF_sv_WriteString (void)
 {
-	MSG_WriteString (WriteDest(), G_STRING(OFS_PARM1));
+	MSG_WriteString (WriteDest(), LOC_GetString(G_STRING(OFS_PARM1)));
 }
 
 static void PF_sv_WriteEntity (void)

--- a/readme.md
+++ b/readme.md
@@ -156,10 +156,8 @@ Generally, the below setup works for multiple engines, including Quakespasm/vkQu
 vkQuake has initial support for playing the 2021 re-release content:
 
 * Copy the vkQuake exe to your rerelease installation.
-* Note: Do not copy vkquake.pak: the entity fixes contained in it might cause ill effects.
 * Note: Do not mix-and-match original and rerelease contents: results may be unpredictable.
 * Extract the English localization file in the rerelease directory:<br/>
   `unzip QuakeEX.kpf localization/loc_english.txt`<br/>
   Note: the extracted file should be in the `rerelease/localization` directory, not `rerelease`.
 * Run vkQuake as you normally do.
-

--- a/readme.md
+++ b/readme.md
@@ -150,3 +150,16 @@ Generally, the below setup works for multiple engines, including Quakespasm/vkQu
 * The files are named in the pattern "tracknn", where "nn" is the CD track number that the file was ripped from. Since the soundtrack starts at the second CD track, MP3 soundtrack files are named "track02.mp3", "track03.mp3", etc. OGG soundtrack files are named "track02.ogg", "track03.ogg", etc. FLAC soundtrack files are named "track02.flac", "track03.flac", etc. WAV soundtrack files are named "track02.wav", "track03.wav", etc.
 
 **See more:** [Quake Soundtrack Solutions (Steam Community)](http://steamcommunity.com/sharedfiles/filedetails/?id=119489135)
+
+# Quake '2021 re-release'
+
+vkQuake has initial support for playing the 2021 re-release content:
+
+* Copy the vkQuake exe to your rerelease installation.
+* Note: Do not copy vkquake.pak: the entity fixes contained in it might cause ill effects.
+* Note: Do not mix-and-match original and rerelease contents: results may be unpredictable.
+* Extract the English localization file in the rerelease directory:<br/>
+  `unzip QuakeEX.kpf localization/loc_english.txt`<br/>
+  Note: the extracted file should be in the `rerelease/localization` directory, not `rerelease`.
+* Run vkQuake as you normally do.
+


### PR DESCRIPTION
This fixes crashes with the 2021 re-release and adds basic support for localized strings so that the new maps display proper messages instead of text id's. Localization data is read from a `loc_english.txt` file in the mod directory, in the same format as the files in the `localization` folder in the `rerelease/QuakeEX.kpf` zip archive. Currently the files need to be copied manually - adding code to read zip files just for this feature seemed like feature creep, and can be added later if necessary.

@sezero, I'm hoping this can also be merged into QS, can you please have a look?