### PR TITLE
Change gl_zfix to use depth bias and enable it by default

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -94,7 +94,7 @@ cvar_t	r_nolerp_list = {"r_nolerp_list", "progs/flame.mdl,progs/flame2.mdl,progs
 extern cvar_t	r_vfog;
 //johnfitz
 
-cvar_t	gl_zfix = {"gl_zfix", "0", CVAR_NONE}; // QuakeSpasm z-fighting fix
+cvar_t	gl_zfix = {"gl_zfix", "1", CVAR_ARCHIVE}; // QuakeSpasm z-fighting fix
 
 cvar_t	r_lavaalpha = {"r_lavaalpha","0",CVAR_NONE};
 cvar_t	r_telealpha = {"r_telealpha","0",CVAR_NONE};

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -1467,7 +1467,7 @@ R_CreatePipelines
 void R_CreatePipelines()
 {
 	int render_pass;
-	int alpha_blend, alpha_test, fullbright_enabled;
+	int alpha_blend, alpha_test, fullbright_enabled, use_zbias;
 	VkResult err;
 
 	Sys_Printf("Creating pipelines\n");
@@ -1997,37 +1997,49 @@ void R_CreatePipelines()
 	shader_stages[1].module = world_frag_module;
 	shader_stages[1].pSpecializationInfo = &specialization_info;
 
-	for (alpha_blend = 0; alpha_blend < 2; ++alpha_blend) {
-		for (alpha_test = 0; alpha_test < 2; ++alpha_test) {
-			for (fullbright_enabled = 0; fullbright_enabled < 2; ++fullbright_enabled) {
-				int pipeline_index = fullbright_enabled + (alpha_test * 2) + (alpha_blend * 4);
+	for (use_zbias = 0; use_zbias < 2; ++use_zbias) {
+		if (use_zbias) {
+			rasterization_state_create_info.depthBiasEnable = VK_TRUE;
+			rasterization_state_create_info.depthBiasConstantFactor = (vulkan_globals.depth_format != VK_FORMAT_D16_UNORM) ? -500.0f : -2.5f;
+		} else {
+			rasterization_state_create_info.depthBiasEnable = VK_FALSE;
+			rasterization_state_create_info.depthBiasConstantFactor = 0.f;
+		}
 
-				specialization_data[0] = fullbright_enabled;
-				specialization_data[1] = alpha_test;
-				specialization_data[2] = alpha_blend;
+		for (alpha_blend = 0; alpha_blend < 2; ++alpha_blend) {
+			for (alpha_test = 0; alpha_test < 2; ++alpha_test) {
+				for (fullbright_enabled = 0; fullbright_enabled < 2; ++fullbright_enabled) {
+					int pipeline_index = fullbright_enabled + (alpha_test * 2) + (alpha_blend * 4) + (use_zbias * 8);
 
-				blend_attachment_state.blendEnable = alpha_blend ? VK_TRUE : VK_FALSE;
-				depth_stencil_state_create_info.depthWriteEnable = alpha_blend ? VK_FALSE : VK_TRUE;
-				if ( pipeline_index > 0 ) {
-					pipeline_create_info.flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
-					pipeline_create_info.basePipelineHandle = vulkan_globals.world_pipelines[0].handle;
-					pipeline_create_info.basePipelineIndex = -1;
-				} else {
-					pipeline_create_info.flags = VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
+					specialization_data[0] = fullbright_enabled;
+					specialization_data[1] = alpha_test;
+					specialization_data[2] = alpha_blend;
+
+					blend_attachment_state.blendEnable = alpha_blend ? VK_TRUE : VK_FALSE;
+					depth_stencil_state_create_info.depthWriteEnable = alpha_blend ? VK_FALSE : VK_TRUE;
+					if ( pipeline_index > 0 ) {
+						pipeline_create_info.flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
+						pipeline_create_info.basePipelineHandle = vulkan_globals.world_pipelines[0].handle;
+						pipeline_create_info.basePipelineIndex = -1;
+					} else {
+						pipeline_create_info.flags = VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
+					}
+
+					assert(vulkan_globals.world_pipelines[pipeline_index].handle == VK_NULL_HANDLE);
+					err = vkCreateGraphicsPipelines(vulkan_globals.device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &vulkan_globals.world_pipelines[pipeline_index].handle);
+					if (err != VK_SUCCESS)
+						Sys_Error("vkCreateGraphicsPipelines failed");
+					GL_SetObjectName((uint64_t)vulkan_globals.world_pipelines[pipeline_index].handle, VK_OBJECT_TYPE_PIPELINE, va("world %d", pipeline_index));
+					vulkan_globals.world_pipelines[pipeline_index].layout = vulkan_globals.world_pipeline_layout;
 				}
-
-				assert(vulkan_globals.world_pipelines[pipeline_index].handle == VK_NULL_HANDLE);
-				err = vkCreateGraphicsPipelines(vulkan_globals.device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &vulkan_globals.world_pipelines[pipeline_index].handle);
-				if (err != VK_SUCCESS)
-					Sys_Error("vkCreateGraphicsPipelines failed");
-				GL_SetObjectName((uint64_t)vulkan_globals.world_pipelines[pipeline_index].handle, VK_OBJECT_TYPE_PIPELINE, va("world %d", pipeline_index));
-				vulkan_globals.world_pipelines[pipeline_index].layout = vulkan_globals.world_pipeline_layout;
 			}
 		}
 	}
 
 	depth_stencil_state_create_info.depthTestEnable = VK_TRUE;
 	depth_stencil_state_create_info.depthWriteEnable = VK_TRUE;
+	rasterization_state_create_info.depthBiasEnable = VK_FALSE;
+	rasterization_state_create_info.depthBiasConstantFactor = 0.f;
 	pipeline_create_info.flags = 0;
 	blend_attachment_state.blendEnable = VK_FALSE;
 	shader_stages[1].pSpecializationInfo = NULL;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -123,7 +123,7 @@ typedef struct vulkan_desc_set_layout_s {
 	int							num_storage_images;
 } vulkan_desc_set_layout_t;
 
-#define WORLD_PIPELINE_COUNT 16
+#define WORLD_PIPELINE_COUNT 8
 
 typedef struct
 {

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -123,7 +123,7 @@ typedef struct vulkan_desc_set_layout_s {
 	int							num_storage_images;
 } vulkan_desc_set_layout_t;
 
-#define WORLD_PIPELINE_COUNT 8
+#define WORLD_PIPELINE_COUNT 16
 
 typedef struct
 {

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 
 extern cvar_t gl_fullbrights, r_drawflat; //johnfitz
-extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 
 int		gl_lightmap_format;
 int		lightmap_bytes;
@@ -194,21 +193,9 @@ void R_DrawBrushModel (entity_t *e)
 	}
 
 	e->angles[0] = -e->angles[0];	// stupid quake bug
-	if (gl_zfix.value)
-	{
-		e->origin[0] -= DIST_EPSILON;
-		e->origin[1] -= DIST_EPSILON;
-		e->origin[2] -= DIST_EPSILON;
-	}
 	float model_matrix[16];
 	IdentityMatrix(model_matrix);
 	R_RotateForEntity (model_matrix, e->origin, e->angles);
-	if (gl_zfix.value)
-	{
-		e->origin[0] += DIST_EPSILON;
-		e->origin[1] += DIST_EPSILON;
-		e->origin[2] += DIST_EPSILON;
-	}
 	e->angles[0] = -e->angles[0];	// stupid quake bug
 
 	float mvp[16];

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
-extern cvar_t gl_fullbrights, r_drawflat, r_oldskyleaf, r_showtris, r_simd; //johnfitz
+extern cvar_t gl_fullbrights, r_drawflat, r_oldskyleaf, r_showtris, r_simd, gl_zfix; //johnfitz
 
 byte *SV_FatPVS (vec3_t org, qmodel_t *worldmodel);
 
@@ -536,7 +536,7 @@ void R_DrawTextureChains_Multitexture (qmodel_t *model, entity_t *ent, texchain_
 	qboolean	fullbright_enabled = false;
 	qboolean	alpha_test = false;
 	qboolean	alpha_blend = alpha < 1.0f;
-	qboolean	use_zbias = model != cl.worldmodel;
+	qboolean	use_zbias = (gl_zfix.value && model != cl.worldmodel);
 	int		lastlightmap;
 	gltexture_t	*fullbright = NULL;
 


### PR DESCRIPTION
This addresses the z-fighting that is still present in the remastered maps due to co-planar geometry, but without requiring manual entity replacements. This change does introduce some artifacts around the edges of bmodels that are aligned with the surrounding map geometry (e.g. the SSG door in e1m1), but unlike the old gl_zfix implementation that shifted entities around, the artifacts are much more subtle. This is also consistent with the new re-release engine - no z-fighting, but some minor artifacts around hidden doors.