### PR TITLE
docs: add openbsd install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,16 @@ Copy all files inside the `vkquake-<version>-linux64` folder in the tar archive 
 
 > 📝 **Note**: Make sure all data files are lowercase, e.g. "id1", not "ID1" and "pak0.pak", not "PAK0.PAK". Some distributions of the game have upper case file names, e.g. from GOG.com.
 
+## OpenBSD
+
+[OpenBSD](https://openbsd.org) includes vkQuake in the standard package repositories since version [6.6](https://www.openbsd.org/66.html).
+
+If you're running `OpenBSD 6.6` or greater you can install the package with:
+
+```console
+$ pkg_add vkquake
+```
+
 ## Quake '2021 re-release'
 
 vkQuake has initial support for playing the 2021 re-release content. Follow installation instructions as above but copy the files into the rerelease folder.


### PR DESCRIPTION
I've been playing vkQuake on my OpenBSD machine as [one of the OpenBSD maintainers](https://openports.se/bbmaint.php?maint=thfr|a|openbsd.org) took the time to port it and add it to the [default package repositories](https://openports.se/games/vkquake). I figured it wouldn't hurt to point this installation method out in the install docs.