### PR TITLE
Fix format overflow warning with 32-bit gcc

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2465,7 +2465,7 @@ visdone:
 
 		if (i < mod->numsubmodels-1)
 		{	// duplicate the basic information
-			char	name[10];
+			char	name[12];
 
 			sprintf (name, "*%i", i+1);
 			loadmodel = Mod_FindName (name);


### PR DESCRIPTION
The move to `-Werror` causes a format overflow warning to kill builds with 32-bit GCC (i686, armv{6,7}l). I have no idea why this doesn't cause a similar problem with 64-bit builds. In any case, make the output buffer large enough to suppress the warning.