### PR TITLE
bail on object count != 1

### DIFF
--- a/Quake/cl_demo.c
+++ b/Quake/cl_demo.c
@@ -114,7 +114,7 @@ static int CL_GetDemoMessage (void)
 	}
 
 // get the next message
-	if (fread (&net_message.cursize, 4, 1, cls.demofile) != 4)
+	if (fread (&net_message.cursize, 4, 1, cls.demofile) != 1)
 		return 0;
 	VectorCopy (cl.mviewangles[0], cl.mviewangles[1]);
 	for (i = 0 ; i < 3 ; i++)


### PR DESCRIPTION
this fixes #402 

Optionally, this could just as easily be `!fread...`, but I prefer to be explicit here.