### PR TITLE
Avoid crash in Draw_SubPic when pic->data only contains zeroes

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -671,6 +671,8 @@ void Draw_SubPic (float x, float y, float w, float h, qpic_t *pic, float s1, flo
 	if (scrap_dirty)
 		Scrap_Upload ();
 	memcpy(&gl, pic->data, sizeof(glpic_t));
+	if (!gl.gltexture)
+		return;
 
 	VkBuffer buffer;
 	VkDeviceSize buffer_offset;


### PR DESCRIPTION
Hi, this fixes the crash in vkquake when picking up some items (i.e. grenade box or a chainsaw) in Slayer's Testaments. I am pretty much sure this does not resolve the original issue, which is probably the absence of some resources in some expected places. Unfortunately I can't resolve this properly, as I don't know anything about QuakeC, or even Quake in general. But at least this makes ST somewhat playable.