### PR TITLE
Fix items2 stats (from Spiked)

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -41,7 +41,12 @@ void SV_CalcStats (client_t *client, int *statsi, float *statsf, const char **st
 	size_t   i;
 	edict_t *ent = client->edict;
 	// FIXME: string stats!
-	int      items = (int)((uint32_t)ent->v.items | ((uint32_t)pr_global_struct->serverflags << 28));
+	int items;
+	eval_t *val = GetEdictFieldValue(ent, qcvm->extfields.items2);
+	if (val)
+		items = (int)((uint32_t)ent->v.items | ((uint32_t)val->_float << 23));
+	else
+		items = (int)((uint32_t)ent->v.items | ((uint32_t)pr_global_struct->serverflags << 28));
 
 	memset (statsi, 0, sizeof (*statsi) * MAX_CL_STATS);
 	memset (statsf, 0, sizeof (*statsf) * MAX_CL_STATS);


### PR DESCRIPTION
This is a would be fix for #417 (and other things I suspect), again copied from Spiked, while keeping the `uint32_t` casts style of vkQuake.

Disclamer : I barely know what I'm doing here :)