### PR TITLE
Fix dedicated server tic timing

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -70,7 +70,7 @@ cvar_t host_timescale = {"host_timescale", "0", CVAR_NONE}; // johnfitz
 cvar_t max_edicts = {"max_edicts", "8192", CVAR_NONE};      // johnfitz //ericw -- changed from 2048 to 8192, removed CVAR_ARCHIVE
 cvar_t cl_nocsqc = {"cl_nocsqc", "0", CVAR_NONE};           // spike -- blocks the loading of any csqc modules
 
-cvar_t sys_ticrate = {"sys_ticrate", "0.05", CVAR_NONE}; // dedicated server
+cvar_t sys_ticrate = {"sys_ticrate", "0.025", CVAR_NONE}; // dedicated server
 cvar_t serverprofile = {"serverprofile", "0", CVAR_NONE};
 
 cvar_t fraglimit = {"fraglimit", "0", CVAR_NOTIFY | CVAR_SERVERINFO};
@@ -854,7 +854,7 @@ void _Host_Frame (double time)
 	while ((host_netinterval == 0) || (accumtime >= host_netinterval))
 	{
 		float realframetime = host_frametime;
-		if (host_netinterval)
+		if (host_netinterval && isDedicated == 0)
 		{
 			host_frametime = host_netinterval;
 			accumtime -= host_frametime;
@@ -874,7 +874,7 @@ void _Host_Frame (double time)
 		host_frametime = realframetime;
 		Cbuf_Waited ();
 
-		if (host_netinterval == 0)
+		if (host_netinterval == 0 || isDedicated)
 			break;
 	}
 


### PR DESCRIPTION
The dedicated server limiter sys_ticrate interacts badly with host_maxfps. In the default configuration, every 50ms 3-4 server tics are run back to back and sent to the clients at once, which not only is wasteful but also breaks client interpolation.
This is a minimal fix, which effectively limits dedicated server tic rate to the minimum of both variables.
Also bump default dedicated server tic rate from 20 to 40 Hz.