### PR TITLE
Add support for autocvars (from Spiked) used for ex. Arcane Dimensions

### DIFF
--- a/Quake/cvar.c
+++ b/Quake/cvar.c
@@ -421,6 +421,8 @@ void Cvar_SetQuick (cvar_t *var, const char *value)
 
 	if (var->callback)
 		var->callback (var);
+	if (var->flags & CVAR_AUTOCVAR)
+		PR_AutoCvarChanged(var);
 }
 
 void Cvar_SetValueQuick (cvar_t *var, const float value)

--- a/Quake/cvar.h
+++ b/Quake/cvar.h
@@ -74,6 +74,7 @@ interface from being ambiguous.
 #define CVAR_REGISTERED  (1U << 10) // the var is added to the list of variables
 #define CVAR_CALLBACK    (1U << 16) // var has a callback
 #define CVAR_USERDEFINED (1U << 17) // cvar was created by the user/mod, and needs to be saved a bit differently.
+#define CVAR_AUTOCVAR    (1U << 18)	// cvar changes need to feed back to qc global changes.
 
 typedef void (*cvarcallback_t) (struct cvar_s *);
 

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -5152,6 +5152,39 @@ static void *PR_FindExtGlobal (int type, const char *name)
 	return NULL;
 }
 
+void PR_AutoCvarChanged(cvar_t *var)
+{
+	char *n;
+	ddef_t *glob;
+	qcvm_t *oldqcvm = qcvm;
+	PR_SwitchQCVM(NULL);
+	if (sv.active)
+	{
+		PR_SwitchQCVM(&sv.qcvm);
+		n = va("autocvar_%s", var->name);
+		glob = ED_FindGlobal(n);
+		if (glob)
+		{
+			if (!ED_ParseEpair ((void *)qcvm->globals, glob, var->string, true))
+				Con_Warning("EXT: Unable to configure %s\n", n);
+		}
+		PR_SwitchQCVM(NULL);
+	}
+	if (cl.qcvm.globals)
+	{
+		PR_SwitchQCVM(&cl.qcvm);
+		n = va("autocvar_%s", var->name);
+		glob = ED_FindGlobal(n);
+		if (glob)
+		{
+			if (!ED_ParseEpair ((void *)qcvm->globals, glob, var->string, true))
+				Con_Warning("EXT: Unable to configure %s\n", n);
+		}
+		PR_SwitchQCVM(NULL);
+	}
+	PR_SwitchQCVM(oldqcvm);
+}
+
 void PR_InitExtensions (void)
 {
 	size_t i, g, m;
@@ -5171,6 +5204,7 @@ void PR_InitExtensions (void)
 void PR_EnableExtensions (ddef_t *pr_globaldefs)
 {
 	unsigned int i, j;
+	unsigned int numautocvars = 0;
 
 	for (i = qcvm->numbuiltins; i < countof (qcvm->builtins); i++)
 		qcvm->builtins[i] = PF_Fixme;
@@ -5237,6 +5271,26 @@ void PR_EnableExtensions (ddef_t *pr_globaldefs)
 			}
 		}
 	}
+
+	//autocvars
+	for (i = 0; i < (unsigned int)qcvm->progs->numglobaldefs; i++)
+	{
+		const char *n = PR_GetString(qcvm->globaldefs[i].s_name);
+		if (!strncmp(n, "autocvar_", 9))
+		{
+			//really crappy approach
+			cvar_t *var = Cvar_Create(n + 9, PR_UglyValueString (qcvm->globaldefs[i].type, (eval_t*)(qcvm->globals + qcvm->globaldefs[i].ofs)));
+			numautocvars++;
+			if (!var)
+				continue;	//name conflicts with a command?
+	
+			if (!ED_ParseEpair ((void *)qcvm->globals, &pr_globaldefs[i], var->string, true))
+				Con_Warning("EXT: Unable to configure %s\n", n);
+			var->flags |= CVAR_AUTOCVAR;
+		}
+	}
+	if (numautocvars)
+		Con_DPrintf2("Found %i autocvars\n", numautocvars);
 }
 
 void PR_DumpPlatform_f (void)


### PR DESCRIPTION
This should be a fix for #426: 
> Bug 2: Difficulty level shown on HUD when pressing the Tab key remains "skill 1" regardless of what difficulty you chose

Apparently as seen in Arcane Dimensions source, the skill display is constructed using an `autocvar` that is trensient to the map Hub (if you save here, and reload, skill is back to 1) but travels effectively to the chosen map. 
Then, when saved in that map, the usual `skill` is properly kept and restored at load. 

So I think it is OK :) I dragged the machinery from Spiked again.

I've gone there when I noticed that using `pr_checkextension 0` made the Skill on Status Bar update properly: so it lead to the way Hud was drawn with CSQC (I'm just discovering all this stuff..) So when there are no PR extensions it just works, because the classic `skill` CVAR is used to display in the Sbar using the traditional method. (Quakespasm classic, Ironwail)