### PR TITLE
UDP networking: make sure sendNext runs after ack

### DIFF
--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -250,8 +250,6 @@ static int ReSendMessage (qsocket_t *sock)
 	packetBuffer.sequence = BigLong (sock->sendSequence - 1);
 	Q_memcpy (packetBuffer.data, sock->sendMessage, dataLen);
 
-	sock->sendNext = false;
-
 	if (sfunc.Write (sock->socket, (byte *)&packetBuffer, packetLen, &sock->addr) == -1)
 		return -1;
 
@@ -488,11 +486,11 @@ qsocket_t *Datagram_GetAnyMessage (void)
 		if (!s->isvirtual)
 			continue;
 
+		if (s->sendNext)
+			SendMessageNext (s);
 		if (!s->canSend)
 			if ((net_time - s->lastSendTime) > 1.0)
 				ReSendMessage (s);
-		if (s->sendNext)
-			SendMessageNext (s);
 
 		if (net_time - s->lastMessageTime > ((!s->ackSequence) ? net_connecttimeout.value : net_messagetimeout.value))
 		{ // timed out, kick them


### PR DESCRIPTION
Fixes a race where a server hitch of over one second would hang connected clients that were in the middle of receiving a multi-packet reliable message, commonly seen when switching to a large map on a listen server.
The issue is Datagram_ProcessPacket() advances ackSequence and sets sendNext to true, expecting SendMessageNext() to advance sendSequence. But the timeout check happens before that, and ReSendMessage() sets sendNext to false, leaving the connection in an unrecoverable state.