### PR TITLE
Add the missing pieces for UF_TRAILEFFECT and UF_TAGINFO from QSS

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -463,14 +463,14 @@ static unsigned int CLFTE_ReadDelta (unsigned int entnum, entity_state_t *news, 
 	if (bits & UF_TRAILEFFECT)
 	{
 		unsigned short v = MSG_ReadShort ();
-		/*news->emiteffectnum = 0;*/
-		/*news->traileffectnum = v & 0x3fff;*/
+		news->emiteffectnum = 0;
+		news->traileffectnum = v & 0x3fff;
 		if (v & 0x8000)
-			/*news->emiteffectnum = */ MSG_ReadShort () /*& 0x3fff*/;
-		/*if (news->traileffectnum >= MAX_PARTICLETYPES)
+			news->emiteffectnum = MSG_ReadShort() & 0x3fff;
+		if (news->traileffectnum >= MAX_PARTICLETYPES)
 		    news->traileffectnum = 0;
 		if (news->emiteffectnum >= MAX_PARTICLETYPES)
-		    news->emiteffectnum = 0;*/
+			news->emiteffectnum = 0;
 	}
 
 	if (bits & UF_COLORMOD)

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -191,6 +191,10 @@ static unsigned int MSGFTE_DeltaCalcBits (entity_state_t *from, entity_state_t *
 		bits |= UF_ALPHA;
 	if (to->colormod[0] != from->colormod[0] || to->colormod[1] != from->colormod[1] || to->colormod[2] != from->colormod[2])
 		bits |= UF_COLORMOD;
+    if (to->tagentity != from->tagentity || to->tagindex != from->tagindex)
+		bits |= UF_TAGINFO;
+   if (to->traileffectnum != from->traileffectnum || to->emiteffectnum != from->emiteffectnum)
+		bits |= UF_TRAILEFFECT;
 
 	return bits;
 }
@@ -340,6 +344,23 @@ static void MSGFTE_WriteEntityUpdate (unsigned int bits, entity_state_t *state, 
 		MSG_WriteByte (msg, (state->alpha - 1) & 0xff);
 	if (bits & UF_SCALE)
 		MSG_WriteByte (msg, state->scale);
+
+	if (bits & UF_TAGINFO)
+	{
+		MSG_WriteEntity(msg, state->tagentity, pext2);
+		MSG_WriteByte(msg, state->tagindex);
+	}
+
+	if (bits & UF_TRAILEFFECT)
+	{
+		if (state->emiteffectnum)
+		{	//3 spare bits. so that's nice (this is guarenteed to be 14 bits max due to precaches using the upper two bits).
+			MSG_WriteShort(msg, (state->traileffectnum&0x3fff)|0x8000);
+			MSG_WriteShort(msg, state->emiteffectnum&0x3fff);
+		}
+		else
+			MSG_WriteShort(msg, state->traileffectnum&0x3fff);
+	}
 
 	if (bits & UF_COLORMOD)
 	{
@@ -1214,7 +1235,7 @@ void SV_StartSound (edict_t *entity, float *origin, int channel, const char *sam
 			continue;
 		if ((field_mask & (SND_LARGEENTITY | SND_LARGESOUND)) && (!client->protocol_pext2 || sv.protocol == PROTOCOL_NETQUAKE))
 			continue;
-
+		
 		// directed messages go only to the entity the are targeted on
 		MSG_WriteByte (&client->datagram, svc_sound);
 		MSG_WriteByte (&client->datagram, field_mask);


### PR DESCRIPTION
Those attributes were half-ported probably because pieces get lost when importing QSS FTE extensions. These are the missing pieces making those capabilities working. (in theory) 