### PR TITLE
Fix for missing sounds in protocols > 15

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1212,7 +1212,8 @@ void SV_StartSound (edict_t *entity, float *origin, int channel, const char *sam
 			continue;
 		if (sound_num >= client->limit_sounds)
 			continue;
-		if ((field_mask & (SND_LARGEENTITY | SND_LARGESOUND)) && (!client->protocol_pext2 || sv.protocol == PROTOCOL_NETQUAKE))
+		//PROTOCOL_NETQUAKE do not support more than 256 sounds and/or 8192 entities.
+		if ((field_mask & (SND_LARGEENTITY | SND_LARGESOUND)) && (sv.protocol == PROTOCOL_NETQUAKE))
 			continue;
 
 		// directed messages go only to the entity the are targeted on


### PR DESCRIPTION
This is the fix I suggested for #426:
> Bug 1: Some sounds specific to AD won't play (examples: breakable windows, flying skulls and necromancers in ad_necrokeep)

This allows more than 256 sounds independently of protocol extensions presence, except for PROTOCOL_NETQUAKE where it behaves like Quakspasm: such cached sounds > 256 are not played.