### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ Misc/vq_pak/vkquake.pak
 Quake/*.dll
 Quake/*.o
 Quake/history.txt
-Quake/id1/
+Quake/*/
 Quake/vkquake
 Quake/vkQuake.exe
 Quake/vkQuake.res


### PR DESCRIPTION
git will ignore any subfolder inside Quake/. Quake/id1 and any mods (like Quake/honey) will be excluded from this repository.