### PR TITLE
Mark brush lightmaps for GPU update

### DIFF
--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -244,6 +244,8 @@ void R_DrawBrushModel (entity_t *e)
 			R_ChainSurface (psurf, chain_model);
 			if (!r_gpulightmapupdate.value)
 				R_RenderDynamicLightmaps (psurf);
+			else if (psurf->lightmaptexturenum >= 0)
+				lightmaps[psurf->lightmaptexturenum].modified = true;
 			rs_brushpolys++;
 		}
 	}


### PR DESCRIPTION
This fixes stale lightning if brush models end up in their own lightmap with no surfaces marking it as modified.