### PR TITLE
Loopback networking: send think interval

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -433,7 +433,11 @@ static unsigned int CLFTE_ReadDelta (unsigned int entnum, entity_state_t *news, 
 	}
 	if (bits & UF_UNUSED2)
 	{
+#ifdef LERP_BANDAID
+		news->lerp = MSG_ReadShort ();
+#else
 		Host_EndGame ("UF_UNUSED2 bit\n");
+#endif
 	}
 	if (bits & UF_UNUSED1)
 	{
@@ -503,6 +507,13 @@ static void CL_EntitiesDeltaed (void)
 
 		ent->alpha = ent->netstate.alpha;
 		ent->lerpflags &= ~LERP_FINISH;
+#ifdef LERP_BANDAID
+		if (ent->netstate.lerp > 0)
+		{
+			ent->lerpfinish = ent->msgtime + (ent->netstate.lerp - 1) / 1000.f; 
+			ent->lerpflags |= LERP_FINISH;
+		}
+#endif
 
 		model = cl.model_precache[ent->netstate.modelindex];
 		if (model != ent->model)

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -382,6 +382,9 @@ typedef struct entity_state_s
 #define ES_SOLID_BSP   31
 #define ES_SOLID_HULL1 0x80201810
 #define ES_SOLID_HULL2 0x80401820
+#ifdef LERP_BANDAID
+	unsigned short lerp;
+#endif
 } entity_state_t;
 #define EFLAGS_STEP          1
 //#define EFLAGS_GLOWTRAIL		2

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -71,6 +71,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define PSET_SCRIPT            // enable the scriptable particle system (poorly ported from FTE)
 #define PSET_SCRIPT_EFFECTINFO // scripted particle system can load dp's effects
 
+#define LERP_BANDAID // HACK: send think interval over FTE protocol (loopback only, no demos)
+
 #include "q_stdinc.h"
 
 // !!! if this is changed, it must be changed in d_ifacea.h too !!!


### PR DESCRIPTION
This workarounds #309 until a better solution comes around.
In the interest of compatibility, it is never sent across the network, and is automatically disabled while recording demos.