### PR TITLE
fix MinGW format string 'unknown conversion type character' warnings :

### DIFF
--- a/Quake/mimalloc/alloc-aligned.c
+++ b/Quake/mimalloc/alloc-aligned.c
@@ -51,19 +51,19 @@ static void* mi_heap_malloc_zero_aligned_at(mi_heap_t* const heap, const size_t 
   mi_assert(alignment > 0);
   if (mi_unlikely(alignment==0 || !_mi_is_power_of_two(alignment))) { // require power-of-two (see <https://en.cppreference.com/w/c/memory/aligned_alloc>)
     #if MI_DEBUG > 0
-    _mi_error_message(EOVERFLOW, "aligned allocation requires the alignment to be a power-of-two (size %zu, alignment %zu)\n", size, alignment);
+    _mi_error_message(EOVERFLOW, "aligned allocation requires the alignment to be a power-of-two (size %" MI_PRISZU ", alignment %" MI_PRISZU ")\n", size, alignment);
     #endif
     return NULL;
   }
   if (mi_unlikely(alignment > MI_ALIGNMENT_MAX)) {  // we cannot align at a boundary larger than this (or otherwise we cannot find segment headers)
     #if MI_DEBUG > 0
-    _mi_error_message(EOVERFLOW, "aligned allocation has a maximum alignment of %zu (size %zu, alignment %zu)\n", MI_ALIGNMENT_MAX, size, alignment);
+    _mi_error_message(EOVERFLOW, "aligned allocation has a maximum alignment of %" MI_PRISZU " (size %" MI_PRISZU ", alignment %" MI_PRISZU ")\n", MI_ALIGNMENT_MAX, size, alignment);
     #endif
     return NULL;
   }
   if (mi_unlikely(size > PTRDIFF_MAX)) {          // we don't allocate more than PTRDIFF_MAX (see <https://sourceware.org/ml/libc-announce/2019/msg00001.html>)                                                    
     #if MI_DEBUG > 0
-    _mi_error_message(EOVERFLOW, "aligned allocation request is too large (size %zu, alignment %zu)\n", size, alignment);
+    _mi_error_message(EOVERFLOW, "aligned allocation request is too large (size %" MI_PRISZU ", alignment %" MI_PRISZU ")\n", size, alignment);
     #endif
     return NULL;
   }

--- a/Quake/mimalloc/alloc-posix.c
+++ b/Quake/mimalloc/alloc-posix.c
@@ -85,7 +85,7 @@ mi_decl_nodiscard mi_decl_restrict void* mi_pvalloc(size_t size) mi_attr_noexcep
 mi_decl_nodiscard mi_decl_restrict void* mi_aligned_alloc(size_t alignment, size_t size) mi_attr_noexcept {
   if (mi_unlikely((size&(alignment-1)) != 0)) { // C11 requires alignment>0 && integral multiple, see <https://en.cppreference.com/w/c/memory/aligned_alloc>
     #if MI_DEBUG > 0
-    _mi_error_message(EOVERFLOW, "(mi_)aligned_alloc requires the size to be an integral multiple of the alignment (size %zu, alignment %zu)\n", size, alignment);
+    _mi_error_message(EOVERFLOW, "(mi_)aligned_alloc requires the size to be an integral multiple of the alignment (size %" MI_PRISZU ", alignment %" MI_PRISZU ")\n", size, alignment);
     #endif
     return NULL;
   }

--- a/Quake/mimalloc/alloc.c
+++ b/Quake/mimalloc/alloc.c
@@ -186,7 +186,7 @@ static mi_decl_noinline bool mi_check_is_double_freex(const mi_page_t* page, con
       mi_list_contains(page, page->local_free, block) ||
       mi_list_contains(page, mi_page_thread_free(page), block))
   {
-    _mi_error_message(EAGAIN, "double free detected of block %p with size %zu\n", block, mi_page_block_size(page));
+    _mi_error_message(EAGAIN, "double free detected of block %p with size %" MI_PRISZU "\n", block, mi_page_block_size(page));
     return true;
   }
   return false;
@@ -255,7 +255,7 @@ static void mi_check_padding(const mi_page_t* page, const mi_block_t* block) {
   size_t size;
   size_t wrong;
   if (!mi_verify_padding(page,block,&size,&wrong)) {
-    _mi_error_message(EFAULT, "buffer overflow in heap block %p of size %zu: write after %zu bytes\n", block, size, wrong );
+    _mi_error_message(EFAULT, "buffer overflow in heap block %p of size %" MI_PRISZU ": write after %" MI_PRISZU " bytes\n", block, size, wrong );
   }
 }
 

--- a/Quake/mimalloc/arena.c
+++ b/Quake/mimalloc/arena.c
@@ -251,12 +251,12 @@ void _mi_arena_free(void* p, size_t size, size_t memid, bool all_committed, mi_o
     const size_t blocks = mi_block_count_of_size(size);
     // checks
     if (arena == NULL) {
-      _mi_error_message(EINVAL, "trying to free from non-existent arena: %p, size %zu, memid: 0x%zx\n", p, size, memid);
+      _mi_error_message(EINVAL, "trying to free from non-existent arena: %p, size %" MI_PRISZU ", memid: 0x%" MI_PRISZX "\n", p, size, memid);
       return;
     }
     mi_assert_internal(arena->field_count > mi_bitmap_index_field(bitmap_idx));
     if (arena->field_count <= mi_bitmap_index_field(bitmap_idx)) {
-      _mi_error_message(EINVAL, "trying to free from non-existent arena block: %p, size %zu, memid: 0x%zx\n", p, size, memid);
+      _mi_error_message(EINVAL, "trying to free from non-existent arena block: %p, size %" MI_PRISZU ", memid: 0x%" MI_PRISZX "\n", p, size, memid);
       return;
     }
     // potentially decommit
@@ -271,7 +271,7 @@ void _mi_arena_free(void* p, size_t size, size_t memid, bool all_committed, mi_o
     // and make it available to others again 
     bool all_inuse = _mi_bitmap_unclaim_across(arena->blocks_inuse, arena->field_count, blocks, bitmap_idx);
     if (!all_inuse) {
-      _mi_error_message(EAGAIN, "trying to free an already freed block: %p, size %zu\n", p, size);
+      _mi_error_message(EAGAIN, "trying to free an already freed block: %p, size %" MI_PRISZU "\n", p, size);
       return;
     };
   }
@@ -348,10 +348,10 @@ int mi_reserve_os_memory(size_t size, bool commit, bool allow_large) mi_attr_noe
   if (start==NULL) return ENOMEM;
   if (!mi_manage_os_memory(start, size, (large || commit), large, true, -1)) {
     _mi_os_free_ex(start, size, commit, &_mi_stats_main);
-    _mi_verbose_message("failed to reserve %zu k memory\n", _mi_divide_up(size,1024));
+    _mi_verbose_message("failed to reserve %" MI_PRISZU " k memory\n", _mi_divide_up(size,1024));
     return ENOMEM;
   }
-  _mi_verbose_message("reserved %zu KiB memory%s\n", _mi_divide_up(size,1024), large ? " (in large os pages)" : "");
+  _mi_verbose_message("reserved %" MI_PRISZU " KiB memory%s\n", _mi_divide_up(size,1024), large ? " (in large os pages)" : "");
   return 0;
 }
 
@@ -377,9 +377,9 @@ void mi_debug_show_arenas(void) mi_attr_noexcept {
     mi_arena_t* arena = mi_atomic_load_ptr_relaxed(mi_arena_t, &mi_arenas[i]);
     if (arena == NULL) break;
     size_t inuse_count = 0;
-    _mi_verbose_message("arena %zu: %zu blocks with %zu fields\n", i, arena->block_count, arena->field_count);
+    _mi_verbose_message("arena %" MI_PRISZU ": %" MI_PRISZU " blocks with %" MI_PRISZU " fields\n", i, arena->block_count, arena->field_count);
     inuse_count += mi_debug_show_bitmap("  ", arena->blocks_inuse, arena->field_count);
-    _mi_verbose_message("  blocks in use ('x'): %zu\n", inuse_count);
+    _mi_verbose_message("  blocks in use ('x'): %" MI_PRISZU "\n", inuse_count);
   }
 }
 
@@ -395,10 +395,10 @@ int mi_reserve_huge_os_pages_at(size_t pages, int numa_node, size_t timeout_msec
   size_t pages_reserved = 0;
   void* p = _mi_os_alloc_huge_os_pages(pages, numa_node, timeout_msecs, &pages_reserved, &hsize);
   if (p==NULL || pages_reserved==0) {
-    _mi_warning_message("failed to reserve %zu GiB huge pages\n", pages);
+    _mi_warning_message("failed to reserve %" MI_PRISZU " GiB huge pages\n", pages);
     return ENOMEM;
   }
-  _mi_verbose_message("numa node %i: reserved %zu GiB huge pages (of the %zu GiB requested)\n", numa_node, pages_reserved, pages);
+  _mi_verbose_message("numa node %i: reserved %" MI_PRISZU " GiB huge pages (of the %" MI_PRISZU " GiB requested)\n", numa_node, pages_reserved, pages);
 
   if (!mi_manage_os_memory(p, hsize, true, true, true, numa_node)) {
     _mi_os_free_huge_pages(p, hsize, &_mi_stats_main);

--- a/Quake/mimalloc/init.c
+++ b/Quake/mimalloc/init.c
@@ -216,7 +216,7 @@ static mi_thread_data_t* mi_thread_data_alloc(void) {
     td = (mi_thread_data_t*)_mi_os_alloc(sizeof(mi_thread_data_t), &_mi_stats_main);
     if (td == NULL) {
       // really out of memory
-      _mi_error_message(ENOMEM, "unable to allocate thread local heap metadata (%zu bytes)\n", sizeof(mi_thread_data_t));
+      _mi_error_message(ENOMEM, "unable to allocate thread local heap metadata (%" MI_PRISZU " bytes)\n", sizeof(mi_thread_data_t));
     }
   }
   return td;
@@ -427,7 +427,7 @@ void mi_thread_init(void) mi_attr_noexcept
 
   _mi_stat_increase(&_mi_stats_main.threads, 1);
   mi_atomic_increment_relaxed(&thread_count);
-  //_mi_verbose_message("thread init: 0x%zx\n", _mi_thread_id());
+  //_mi_verbose_message("thread init: 0x%" MI_PRISZX "\n", _mi_thread_id());
 }
 
 void mi_thread_done(void) mi_attr_noexcept {
@@ -565,7 +565,7 @@ static void mi_detect_cpu_features(void) {
 void mi_process_init(void) mi_attr_noexcept {
   // ensure we are called once
   if (_mi_process_is_initialized) return;
-  _mi_verbose_message("process init: 0x%zx\n", _mi_thread_id());
+  _mi_verbose_message("process init: 0x%" MI_PRISZX "\n", _mi_thread_id());
   _mi_process_is_initialized = true;
   mi_process_setup_auto_thread_done();
 
@@ -631,7 +631,7 @@ static void mi_process_done(void) {
     mi_stats_print(NULL);
   }
   mi_allocator_done();  
-  _mi_verbose_message("process done: 0x%zx\n", _mi_heap_main.thread_id);
+  _mi_verbose_message("process done: 0x%" MI_PRISZX "\n", _mi_heap_main.thread_id);
   os_preloading = true; // don't call the C runtime anymore
 }
 

--- a/Quake/mimalloc/mimalloc-internal.h
+++ b/Quake/mimalloc/mimalloc-internal.h
@@ -10,6 +10,17 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #include "mimalloc-types.h"
 
+#if defined(_WIN64)
+#define MI_PRISZU "I64u"
+#define MI_PRISZX "I64x"
+#elif defined(_WIN32)
+#define MI_PRISZU "u"
+#define MI_PRISZX "x"
+#else
+#define MI_PRISZU "zu"
+#define MI_PRISZX "zx"
+#endif
+
 #if (MI_DEBUG>0)
 #define mi_trace_message(...)  _mi_trace_message(__VA_ARGS__)
 #else
@@ -301,7 +312,7 @@ static inline bool mi_count_size_overflow(size_t count, size_t size, size_t* tot
     return false;
   }
   else if (mi_unlikely(mi_mul_overflow(count, size, total))) {
-    _mi_error_message(EOVERFLOW, "allocation request is too large (%zu * %zu bytes)\n", count, size);
+    _mi_error_message(EOVERFLOW, "allocation request is too large (%" MI_PRISZU " * %" MI_PRISZU " bytes)\n", count, size);
     *total = SIZE_MAX;
     return true;
   }
@@ -681,7 +692,7 @@ static inline mi_block_t* mi_block_next(const mi_page_t* page, const mi_block_t*
   // check for free list corruption: is `next` at least in the same page?
   // TODO: check if `next` is `page->block_size` aligned?
   if (mi_unlikely(next!=NULL && !mi_is_in_same_page(block, next))) {
-    _mi_error_message(EFAULT, "corrupted free list entry of size %zub at %p: value 0x%zx\n", mi_page_block_size(page), block, (uintptr_t)next);
+    _mi_error_message(EFAULT, "corrupted free list entry of size %" MI_PRISZU "b at %p: value 0x%" MI_PRISZX "\n", mi_page_block_size(page), block, (uintptr_t)next);
     next = NULL;
   }
   return next;

--- a/Quake/mimalloc/options.c
+++ b/Quake/mimalloc/options.c
@@ -346,7 +346,7 @@ void _mi_fprintf( mi_output_fun* out, void* arg, const char* fmt, ... ) {
 static void mi_vfprintf_thread(mi_output_fun* out, void* arg, const char* prefix, const char* fmt, va_list args) {
   if (prefix != NULL && strlen(prefix) <= 32 && !_mi_is_main_thread()) {
     char tprefix[64];
-    snprintf(tprefix, sizeof(tprefix), "%sthread 0x%zx: ", prefix, _mi_thread_id());
+    snprintf(tprefix, sizeof(tprefix), "%sthread 0x%" MI_PRISZX ": ", prefix, _mi_thread_id());
     mi_vfprintf(out, arg, tprefix, fmt, args);
   }
   else {

--- a/Quake/mimalloc/page.c
+++ b/Quake/mimalloc/page.c
@@ -814,7 +814,7 @@ static mi_page_t* mi_find_page(mi_heap_t* heap, size_t size) mi_attr_noexcept {
   const size_t req_size = size - MI_PADDING_SIZE;  // correct for padding_size in case of an overflow on `size`  
   if (mi_unlikely(req_size > (MI_MEDIUM_OBJ_SIZE_MAX - MI_PADDING_SIZE) )) {
     if (mi_unlikely(req_size > PTRDIFF_MAX)) {  // we don't allocate more than PTRDIFF_MAX (see <https://sourceware.org/ml/libc-announce/2019/msg00001.html>)
-      _mi_error_message(EOVERFLOW, "allocation request is too large (%zu bytes)\n", req_size);
+      _mi_error_message(EOVERFLOW, "allocation request is too large (%" MI_PRISZU " bytes)\n", req_size);
       return NULL;
     }
     else {
@@ -857,7 +857,7 @@ void* _mi_malloc_generic(mi_heap_t* heap, size_t size) mi_attr_noexcept
 
   if (mi_unlikely(page == NULL)) { // out of memory
     const size_t req_size = size - MI_PADDING_SIZE;  // correct for padding_size in case of an overflow on `size`  
-    _mi_error_message(ENOMEM, "unable to allocate memory (%zu bytes)\n", req_size);
+    _mi_error_message(ENOMEM, "unable to allocate memory (%" MI_PRISZU " bytes)\n", req_size);
     return NULL;
   }
 

--- a/Quake/mimalloc/region.c
+++ b/Quake/mimalloc/region.c
@@ -190,7 +190,7 @@ static bool mi_region_try_alloc_os(size_t blocks, bool commit, bool allow_large,
   if (idx >= MI_REGION_MAX) {
     mi_atomic_decrement_acq_rel(&regions_count);
     _mi_arena_free(start, MI_REGION_SIZE, arena_memid, region_commit, tld->stats);
-    _mi_warning_message("maximum regions used: %zu GiB (perhaps recompile with a larger setting for MI_HEAP_REGION_MAX_SIZE)", _mi_divide_up(MI_HEAP_REGION_MAX_SIZE, MI_GiB));
+    _mi_warning_message("maximum regions used: %" MI_PRISZU " GiB (perhaps recompile with a larger setting for MI_HEAP_REGION_MAX_SIZE)", _mi_divide_up(MI_HEAP_REGION_MAX_SIZE, MI_GiB));
     return false;
   }
 
@@ -365,7 +365,7 @@ void* _mi_mem_alloc_aligned(size_t size, size_t alignment, bool* commit, bool* l
   if (blocks <= MI_REGION_MAX_OBJ_BLOCKS && alignment <= MI_SEGMENT_ALIGN) {
     p = mi_region_try_alloc(blocks, commit, large, is_pinned, is_zero, memid, tld);    
     if (p == NULL) {
-      _mi_warning_message("unable to allocate from region: size %zu\n", size);
+      _mi_warning_message("unable to allocate from region: size %" MI_PRISZU "\n", size);
     }
   }
   if (p == NULL) {

--- a/Quake/mimalloc/segment.c
+++ b/Quake/mimalloc/segment.c
@@ -449,7 +449,7 @@ static void mi_segment_commit_mask(mi_segment_t* segment, bool conservative, uin
   
   size_t bitcount = *full_size / MI_COMMIT_SIZE; // can be 0
   if (bitidx + bitcount > MI_COMMIT_MASK_BITS) {
-    _mi_warning_message("commit mask overflow: idx=%zu count=%zu start=%zx end=%zx p=0x%p size=%zu fullsize=%zu\n", bitidx, bitcount, start, end, p, size, *full_size);
+    _mi_warning_message("commit mask overflow: idx=%" MI_PRISZU " count=%" MI_PRISZU " start=%" MI_PRISZX " end=%" MI_PRISZX " p=0x%p size=%" MI_PRISZU " fullsize=%" MI_PRISZU "\n", bitidx, bitcount, start, end, p, size, *full_size);
   }
   mi_assert_internal((bitidx + bitcount) <= MI_COMMIT_MASK_BITS);
   mi_commit_mask_create(bitidx, bitcount, cm);


### PR DESCRIPTION
```
In file included from mimalloc/static.c:39:0,
                 from mem.c:30:
mimalloc/options.c: In function 'mi_vfprintf_thread':
mimalloc/options.c:349:53: warning: unknown conversion type character 'z' in format [-Wformat=]
     snprintf(tprefix, sizeof(tprefix), "%sthread 0x%zx: ", prefix, _mi_thread_id());
                                                     ^
mimalloc/options.c:349:40: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(tprefix, sizeof(tprefix), "%sthread 0x%zx: ", prefix, _mi_thread_id());
                                        ^~~~~~~~~~~~~~~~~~
```
MinGW builds against msvcrt.dll by default and %z isn't supported there,
as far as I can remember. So, invent and use `MI_PRISZU` and `MI_PRISZX` macros
in mimalloc-internal.h and use them instead.