### PR TITLE
replace naive spin wait with native primitive

### DIFF
--- a/Quake/tasks.c
+++ b/Quake/tasks.c
@@ -128,27 +128,7 @@ SpinWaitSemaphore
 */
 static inline void SpinWaitSemaphore (SDL_sem *semaphore)
 {
-	int remaining_sleeps = WAIT_SLEEP_COUNT;
-	int remaining_spins = WAIT_SPIN_COUNT;
-	int result = 0;
-	while ((result = SDL_SemTryWait (semaphore)) != 0)
-	{
-		if (--remaining_spins == 0)
-		{
-			if (--remaining_sleeps == 0)
-				break;
-			else
-				SDL_Delay (0);
-			remaining_spins = WAIT_SPIN_COUNT;
-#ifdef USE_SSE2
-			// Don't have to actually check for SSE2 support, the
-			// instruction is backwards compatible and executes as a NOP
-			_mm_pause ();
-#endif
-		}
-	}
-	if (result != 0)
-		SDL_SemWait (semaphore);
+	SDL_SemWait (semaphore);
 }
 
 /*


### PR DESCRIPTION
According to "perf record", vkQuake on intro spend 20 - 25% of CPU in https://github.com/Novum/vkQuake/blob/master/Quake/tasks.c#L129

According to https://www.realworldtech.com/forum/?threadid=189711&curpostid=189723 , naive spin wait lock/semaphore/etc should not be used in userspace applications.

After replace, program uses less(approx. 10%) CPU, and I have not notice any latency degradation.