### PR TITLE
MacOS fixes

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -166,7 +166,8 @@ ifeq ($(shell test -d /opt/homebrew && echo true),true)
 COMMON_LIBS+= -L/opt/homebrew/lib
 CFLAGS+= -I/opt/homebrew/include
 endif
-COMMON_LIBS+= -lMoltenVK
+CFLAGS+=-DAPPLE
+COMMON_LIBS+= -lvulkan
 endif
 
 LIBS := $(COMMON_LIBS) $(NET_LIBS) $(CODECLIBS)

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -166,7 +166,6 @@ ifeq ($(shell test -d /opt/homebrew && echo true),true)
 COMMON_LIBS+= -L/opt/homebrew/lib
 CFLAGS+= -I/opt/homebrew/include
 endif
-CFLAGS+=-DAPPLE
 COMMON_LIBS+= -lvulkan
 endif
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -691,9 +691,9 @@ static void R_InitDynamicVertexBuffers ()
 	vkGetBufferMemoryRequirements (vulkan_globals.device, dyn_vertex_buffers[0].buffer, &memory_requirements);
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
-	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-								 ? memory_requirements.size
-								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
+    const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
+                             ? memory_requirements.size
+                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -757,8 +757,8 @@ static void R_InitDynamicIndexBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-								 ? memory_requirements.size
-								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
+                                 ? memory_requirements.size
+                                 : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -822,8 +822,8 @@ static void R_InitDynamicUniformBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-								 ? memory_requirements.size
-								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
+                                 ? memory_requirements.size
+                                 : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -692,8 +692,8 @@ static void R_InitDynamicVertexBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-	                         ? memory_requirements.size
-	                         : (memory_requirements.size + memory_requirements.alignment - align_mod);
+	                             ? memory_requirements.size
+	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -691,9 +691,9 @@ static void R_InitDynamicVertexBuffers ()
 	vkGetBufferMemoryRequirements (vulkan_globals.device, dyn_vertex_buffers[0].buffer, &memory_requirements);
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
-    const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-                             ? memory_requirements.size
-                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
+	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
+	                         ? memory_requirements.size
+	                         : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -757,8 +757,8 @@ static void R_InitDynamicIndexBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-                                 ? memory_requirements.size
-                                 : (memory_requirements.size + memory_requirements.alignment - align_mod);
+	                             ? memory_requirements.size
+	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -822,8 +822,8 @@ static void R_InitDynamicUniformBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-                                 ? memory_requirements.size
-                                 : (memory_requirements.size + memory_requirements.alignment - align_mod);
+	                             ? memory_requirements.size
+	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -1364,27 +1364,31 @@ R_CreateDescriptorPool
 */
 void R_CreateDescriptorPool ()
 {
-	VkDescriptorPoolSize pool_sizes[6];
-	pool_sizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-	pool_sizes[0].descriptorCount = (MAX_SANITY_LIGHTMAPS * 2) + (MAX_GLTEXTURES + 1);
-	pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-	pool_sizes[1].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
-	pool_sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-	pool_sizes[2].descriptorCount = MAX_SANITY_LIGHTMAPS * 2;
-	pool_sizes[3].type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-	pool_sizes[3].descriptorCount = 2;
-	pool_sizes[4].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-	pool_sizes[4].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
+    VkDescriptorPoolSize pool_sizes[7];
+    pool_sizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    pool_sizes[0].descriptorCount = (MAX_SANITY_LIGHTMAPS * 2) + (MAX_GLTEXTURES + 1);
+    pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+    pool_sizes[1].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
+    pool_sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    pool_sizes[2].descriptorCount = MAX_SANITY_LIGHTMAPS * 2;
+    pool_sizes[3].type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    pool_sizes[3].descriptorCount = 2;
+    pool_sizes[4].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    pool_sizes[4].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
+    pool_sizes[5].type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    pool_sizes[5].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
+    pool_sizes[6].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    pool_sizes[6].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
 
-	VkDescriptorPoolCreateInfo descriptor_pool_create_info;
-	memset (&descriptor_pool_create_info, 0, sizeof (descriptor_pool_create_info));
-	descriptor_pool_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-	descriptor_pool_create_info.maxSets = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS + 32;
-	descriptor_pool_create_info.poolSizeCount = 5;
-	descriptor_pool_create_info.pPoolSizes = pool_sizes;
-	descriptor_pool_create_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    VkDescriptorPoolCreateInfo descriptor_pool_create_info;
+    memset (&descriptor_pool_create_info, 0, sizeof (descriptor_pool_create_info));
+    descriptor_pool_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    descriptor_pool_create_info.maxSets = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS + 32;
+    descriptor_pool_create_info.poolSizeCount = 7;
+    descriptor_pool_create_info.pPoolSizes = pool_sizes;
+    descriptor_pool_create_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
 
-	vkCreateDescriptorPool (vulkan_globals.device, &descriptor_pool_create_info, NULL, &vulkan_globals.descriptor_pool);
+    vkCreateDescriptorPool (vulkan_globals.device, &descriptor_pool_create_info, NULL, &vulkan_globals.descriptor_pool);
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -692,8 +692,8 @@ static void R_InitDynamicVertexBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-	                             ? memory_requirements.size
-	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
+								 ? memory_requirements.size
+								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -757,8 +757,8 @@ static void R_InitDynamicIndexBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-	                             ? memory_requirements.size
-	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
+								 ? memory_requirements.size
+								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -822,8 +822,8 @@ static void R_InitDynamicUniformBuffers ()
 
 	const int align_mod = memory_requirements.size % memory_requirements.alignment;
 	const int aligned_size = ((memory_requirements.size % memory_requirements.alignment) == 0)
-	                             ? memory_requirements.size
-	                             : (memory_requirements.size + memory_requirements.alignment - align_mod);
+								 ? memory_requirements.size
+								 : (memory_requirements.size + memory_requirements.alignment - align_mod);
 
 	VkMemoryAllocateInfo memory_allocate_info;
 	memset (&memory_allocate_info, 0, sizeof (memory_allocate_info));
@@ -1364,31 +1364,31 @@ R_CreateDescriptorPool
 */
 void R_CreateDescriptorPool ()
 {
-    VkDescriptorPoolSize pool_sizes[7];
-    pool_sizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    pool_sizes[0].descriptorCount = (MAX_SANITY_LIGHTMAPS * 2) + (MAX_GLTEXTURES + 1);
-    pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-    pool_sizes[1].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
-    pool_sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    pool_sizes[2].descriptorCount = MAX_SANITY_LIGHTMAPS * 2;
-    pool_sizes[3].type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-    pool_sizes[3].descriptorCount = 2;
-    pool_sizes[4].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    pool_sizes[4].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
-    pool_sizes[5].type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-    pool_sizes[5].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
-    pool_sizes[6].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    pool_sizes[6].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
+	VkDescriptorPoolSize pool_sizes[7];
+	pool_sizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	pool_sizes[0].descriptorCount = (MAX_SANITY_LIGHTMAPS * 2) + (MAX_GLTEXTURES + 1);
+	pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+	pool_sizes[1].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
+	pool_sizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+	pool_sizes[2].descriptorCount = MAX_SANITY_LIGHTMAPS * 2;
+	pool_sizes[3].type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+	pool_sizes[3].descriptorCount = 2;
+	pool_sizes[4].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+	pool_sizes[4].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
+	pool_sizes[5].type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+	pool_sizes[5].descriptorCount = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS;
+	pool_sizes[6].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+	pool_sizes[6].descriptorCount = 16 + (MAX_SANITY_LIGHTMAPS * 2);
 
-    VkDescriptorPoolCreateInfo descriptor_pool_create_info;
-    memset (&descriptor_pool_create_info, 0, sizeof (descriptor_pool_create_info));
-    descriptor_pool_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    descriptor_pool_create_info.maxSets = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS + 32;
-    descriptor_pool_create_info.poolSizeCount = 7;
-    descriptor_pool_create_info.pPoolSizes = pool_sizes;
-    descriptor_pool_create_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+	VkDescriptorPoolCreateInfo descriptor_pool_create_info;
+	memset (&descriptor_pool_create_info, 0, sizeof (descriptor_pool_create_info));
+	descriptor_pool_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+	descriptor_pool_create_info.maxSets = MAX_GLTEXTURES + MAX_SANITY_LIGHTMAPS + 32;
+	descriptor_pool_create_info.poolSizeCount = 7;
+	descriptor_pool_create_info.pPoolSizes = pool_sizes;
+	descriptor_pool_create_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
 
-    vkCreateDescriptorPool (vulkan_globals.device, &descriptor_pool_create_info, NULL, &vulkan_globals.descriptor_pool);
+	vkCreateDescriptorPool (vulkan_globals.device, &descriptor_pool_create_info, NULL, &vulkan_globals.descriptor_pool);
 }
 
 /*

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -105,7 +105,7 @@ cvar_t                          vid_fsaamode = {"vid_fsaamode", "0", CVAR_ARCHIV
 cvar_t                          vid_gamma = {"gamma", "0.9", CVAR_ARCHIVE};       // johnfitz -- moved here from view.c
 cvar_t                          vid_contrast = {"contrast", "1.4", CVAR_ARCHIVE}; // QuakeSpasm, MarkV
 cvar_t                          r_usesops = {"r_usesops", "1", CVAR_ARCHIVE};     // johnfitz
-                                                                                                      // Vulkan
+                                                                                  // Vulkan
 static VkInstance               vulkan_instance;
 static VkPhysicalDevice         vulkan_physical_device;
 static VkPhysicalDeviceFeatures vulkan_physical_device_features;

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -105,7 +105,7 @@ cvar_t                          vid_fsaamode = {"vid_fsaamode", "0", CVAR_ARCHIV
 cvar_t                          vid_gamma = {"gamma", "0.9", CVAR_ARCHIVE};       // johnfitz -- moved here from view.c
 cvar_t                          vid_contrast = {"contrast", "1.4", CVAR_ARCHIVE}; // QuakeSpasm, MarkV
 cvar_t                          r_usesops = {"r_usesops", "1", CVAR_ARCHIVE};     // johnfitz
-                                                                                  // Vulkan
+																				  // Vulkan
 static VkInstance               vulkan_instance;
 static VkPhysicalDevice         vulkan_physical_device;
 static VkPhysicalDeviceFeatures vulkan_physical_device_features;
@@ -623,10 +623,10 @@ static void GL_InitInstance (void)
 			if (strcmp (VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, extension_props[i].extensionName) == 0)
 				vulkan_globals.get_physical_device_properties_2 = true;
 
-            // Adding define as it appears linux/windows sdk v1.3.216.0 do NOT have this macro enabled in non-beta yet
-            // TODO: Check if latest SDK version moves this out of beta. If so, remove APPLE def
-#ifdef APPLE
-            if (strcmp (VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, extension_props[i].extensionName) == 0)
+			// Adding define as it appears linux/windows sdk v1.3.216.0 do NOT have this macro enabled in non-beta yet
+			// TODO: Check if latest SDK version moves this out of beta. If so, remove APPLE def
+#ifdef __APPLE__
+			if (strcmp (VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, extension_props[i].extensionName) == 0)
 				vulkan_globals.portability_enumeration_availible = true;
 #endif
 #if _DEBUG
@@ -672,15 +672,15 @@ static void GL_InitInstance (void)
 	if (vulkan_globals.get_physical_device_properties_2)
 		instance_extensions[sdl_extension_count + additionalExtensionCount++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
 
-#ifdef APPLE
-    // As of VulkanSDK v1.3.126.0, VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit must be set and VK_KHR_PORTABILITY_ENUMERATION_EXTENSION
-    // enabled to for MoltenVK to work properly. If not set, VkInstance will fail to init. Does not appear to be defined
-    // in the windows/linux SDKs in non-beta headers
-    if (vulkan_globals.portability_enumeration_availible)
-    {
-        instance_create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-        instance_extensions[sdl_extension_count + additionalExtensionCount++] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
-    }
+#ifdef __APPLE__
+	// As of VulkanSDK v1.3.126.0, VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit must be set and VK_KHR_PORTABILITY_ENUMERATION_EXTENSION
+	// enabled to for MoltenVK to work properly. If not set, VkInstance will fail to init. Does not appear to be defined
+	// in the windows/linux SDKs in non-beta headers
+	if (vulkan_globals.portability_enumeration_availible)
+	{
+		instance_create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+		instance_extensions[sdl_extension_count + additionalExtensionCount++] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+	}
 #endif
 
 #ifdef _DEBUG
@@ -1051,12 +1051,12 @@ static void GL_InitDevice (void)
 		device_extensions[numEnabledExtensions++] = VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME;
 	}
 
-    // If portability extentions are enabled, then device extension "VK_KHR_portability_subset" must be as well.
-    // As of 1.3.216.0, there is no VK_KHR_PORTABILITY_SUBSET_NAME macro that is not in beta (as far as I know)
-    if (vulkan_globals.device_portability_subset)
-    {
-        device_extensions[numEnabledExtensions++] = "VK_KHR_portability_subset";
-    }
+	// If portability extentions are enabled, then device extension "VK_KHR_portability_subset" must be as well.
+	// As of 1.3.216.0, there is no VK_KHR_PORTABILITY_SUBSET_NAME macro that is not in beta (as far as I know)
+	if (vulkan_globals.device_portability_subset)
+	{
+		device_extensions[numEnabledExtensions++] = "VK_KHR_portability_subset";
+	}
 
 
 #if defined(VK_EXT_subgroup_size_control)

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -105,7 +105,7 @@ cvar_t                          vid_fsaamode = {"vid_fsaamode", "0", CVAR_ARCHIV
 cvar_t                          vid_gamma = {"gamma", "0.9", CVAR_ARCHIVE};       // johnfitz -- moved here from view.c
 cvar_t                          vid_contrast = {"contrast", "1.4", CVAR_ARCHIVE}; // QuakeSpasm, MarkV
 cvar_t                          r_usesops = {"r_usesops", "1", CVAR_ARCHIVE};     // johnfitz
-																				  // Vulkan
+                                                                                                      // Vulkan
 static VkInstance               vulkan_instance;
 static VkPhysicalDevice         vulkan_physical_device;
 static VkPhysicalDeviceFeatures vulkan_physical_device_features;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -236,12 +236,12 @@ typedef struct
 	qboolean get_surface_capabilities_2;
 	qboolean get_physical_device_properties_2;
 	qboolean vulkan_1_1_available;
-    qboolean portability_enumeration_availible;
+	qboolean portability_enumeration_availible;
 
 	// Device extensions
 	qboolean dedicated_allocation;
 	qboolean full_screen_exclusive;
-    qboolean device_portability_subset;
+	qboolean device_portability_subset;
 
 	// Buffers
 	VkImage color_buffers[NUM_COLOR_BUFFERS];

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -236,10 +236,12 @@ typedef struct
 	qboolean get_surface_capabilities_2;
 	qboolean get_physical_device_properties_2;
 	qboolean vulkan_1_1_available;
+    qboolean portability_enumeration_availible;
 
 	// Device extensions
 	qboolean dedicated_allocation;
 	qboolean full_screen_exclusive;
+    qboolean device_portability_subset;
 
 	// Buffers
 	VkImage color_buffers[NUM_COLOR_BUFFERS];

--- a/Shaders/compileMac.sh
+++ b/Shaders/compileMac.sh
@@ -1,0 +1,46 @@
+#!/bin/zsh
+
+# For now, just compile for release as the debug shaders were fine.
+# Can expand this later or someone with more than a rudimentry knoweldge
+# of shell scripts can fix this!
+
+# VULKAN_SDK should either be set or by default, the SDK will install into /usr/local/bin
+# so if installed properly, glslangValidator SHOULD already be in the path
+
+# Just compile bintoc anyways
+gcc bintoc.c -o bintoc
+
+find . -type f -name "*.vert" | while read f;
+do
+	glslangValidator -V ${f} -o "Compiled/Release/${f%.*}.vspv";
+done
+
+find . -type f -name "*.frag" | while read f;
+do
+  glslangValidator -V ${f} -o "Compiled/Release/${f%.*}.fspv";
+done
+
+find . -type f -name "*.comp" | while read f; do filename=${f} substring="sops"
+if test "${filename#*$substring}" != "$filename";
+then glslangValidator -V ${f} --target-env vulkan1.1 -o "Compiled/Release/${f%.*}.cspv";
+else glslangValidator -V ${f} -o "Compiled/Release/${f%.*}.cspv";
+fi
+done
+
+find . -type f -name "*.vspv" | while read f;
+do
+        ./bintoc ${f} $(basename ${f%.*}_vert_spv) ${f%.*}.vert.c;
+        rm ${f}; # Cleanup .vspv
+done
+
+find . -type f -name "*.fspv" | while read f;
+do
+        ./bintoc ${f} $(basename ${f%.*}_frag_spv) ${f%.*}.frag.c;
+        rm ${f}; # Cleanup .fspv
+done
+
+find . -type f -name "*.cspv" | while read f;
+do
+    ./bintoc ${f} $(basename ${f%.*}_comp_spv) ${f%.*}.comp.c;
+    rm ${f}; # Cleanup .cspv
+done


### PR DESCRIPTION
Here are the changes to get MacOS builds working again. When testing on Windows and Linux, I discovered that the portability extensions haven't been enabled yet, so in the mean time, I have introduced an APPLE define. There appear to be some breaking changes coming down the pipe for Vulkan with regards to api on api wrappers (MoltenVK, DXVK, etc.), so this would have needed to be done anyways.

On line 1058, I had to set the extension name as a string constant as it appears the enum const VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME is NOT available in this version of the SDK. In a future release, I will change this assuming they add it to the non-beta header.

I didn't include the recompiled *.c shader files. Mac users will have to run the compile script to fix the shader issue.