### PR TITLE
Add Model Scale Support

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1203,6 +1203,8 @@ static void CL_ParseUpdate (int bits)
 			ent->alpha = ent->baseline.alpha;
 		if (bits & U_SCALE)
 			ent->netstate.scale = MSG_ReadByte (); // PROTOCOL_RMQ
+		else
+			ent->netstate.scale = ent->baseline.scale;
 		if (bits & U_FRAME2)
 			ent->frame = (ent->frame & 0x00FF) | (MSG_ReadByte () << 8);
 		if (bits & U_MODEL2)
@@ -1242,7 +1244,10 @@ static void CL_ParseUpdate (int bits)
 			ent->alpha = ent->baseline.alpha;
 	}
 	else
+	{
 		ent->alpha = ent->baseline.alpha;
+		ent->netstate.scale = ent->baseline.scale;
+	}
 	// johnfitz
 
 	// johnfitz -- moved here from above
@@ -1315,6 +1320,7 @@ static void CL_ParseBaseline (entity_t *ent, int version) // johnfitz -- added a
 	}
 
 	ent->baseline.alpha = (bits & B_ALPHA) ? MSG_ReadByte () : ENTALPHA_DEFAULT; // johnfitz -- PROTOCOL_FITZQUAKE
+	ent->baseline.scale = ent->netstate.scale;
 }
 
 #define CL_SetStati(stat, val)   cl.statsf[stat] = (cl.stats[stat] = val)

--- a/Quake/gl_refrag.c
+++ b/Quake/gl_refrag.c
@@ -170,7 +170,8 @@ R_AddEfrags
 void R_AddEfrags (entity_t *ent)
 {
 	qmodel_t *entmodel;
-	int       i;
+	vec3_t    boundVec, scaledVec;
+	vec_t     scalefactor;
 
 	if (!ent->model)
 		return;
@@ -180,11 +181,21 @@ void R_AddEfrags (entity_t *ent)
 	r_pefragtopnode = NULL;
 
 	entmodel = ent->model;
-
-	for (i = 0; i < 3; i++)
+	scalefactor = ent->netstate.scale / 16.0f;
+	if (scalefactor != 1.0f)
 	{
-		r_emins[i] = ent->origin[i] + entmodel->mins[i];
-		r_emaxs[i] = ent->origin[i] + entmodel->maxs[i];
+		VectorCopy (entmodel->mins, boundVec);
+		VectorScale (boundVec, scalefactor, scaledVec);
+		VectorAdd (ent->origin, scaledVec, r_emins);
+
+		VectorCopy (entmodel->maxs, boundVec);
+		VectorScale (boundVec, scalefactor, scaledVec);
+		VectorAdd (ent->origin, scaledVec, r_emaxs);
+	}
+	else
+	{
+		VectorAdd (ent->origin, entmodel->mins, r_emins);
+		VectorAdd (ent->origin, entmodel->maxs, r_emaxs);
 	}
 
 	R_SplitEntityOnNode (cl.worldmodel->nodes);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -145,21 +145,40 @@ R_CullModelForEntity -- johnfitz -- uses correct bounds based on rotation
 qboolean R_CullModelForEntity (entity_t *e)
 {
 	vec3_t mins, maxs;
+	vec3_t minbounds, maxbounds;
 
 	if (e->angles[0] || e->angles[2]) // pitch or roll
 	{
-		VectorAdd (e->origin, e->model->rmins, mins);
-		VectorAdd (e->origin, e->model->rmaxs, maxs);
+		VectorCopy (e->model->rmins, minbounds);
+		VectorCopy (e->model->rmaxs, maxbounds);
 	}
 	else if (e->angles[1]) // yaw
 	{
-		VectorAdd (e->origin, e->model->ymins, mins);
-		VectorAdd (e->origin, e->model->ymaxs, maxs);
+		VectorCopy (e->model->ymins, minbounds);
+		VectorCopy (e->model->ymaxs, maxbounds);
 	}
 	else // no rotation
 	{
-		VectorAdd (e->origin, e->model->mins, mins);
-		VectorAdd (e->origin, e->model->maxs, maxs);
+		VectorCopy (e->model->mins, minbounds);
+		VectorCopy (e->model->maxs, maxbounds);
+	}
+
+	vec_t scalefactor = e->netstate.scale / 16.0f;
+	if (scalefactor < 0.001f)
+		scalefactor = 1.0f;
+
+	if (scalefactor != 1.0f)
+	{
+		vec3_t scaledVec;
+		VectorScale (minbounds, scalefactor, scaledVec);
+		VectorAdd (e->origin, scaledVec, mins);
+		VectorScale (maxbounds, scalefactor, scaledVec);
+		VectorAdd (e->origin, scaledVec, maxs);
+	}
+	else
+	{
+		VectorAdd (e->origin, minbounds, mins);
+		VectorAdd (e->origin, maxbounds, maxs);
 	}
 
 	return R_CullBox (mins, maxs);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -399,6 +399,16 @@ void R_DrawAliasModel (cb_context_t *cbx, entity_t *e)
 	float model_matrix[16];
 	IdentityMatrix (model_matrix);
 	R_RotateForEntity (model_matrix, lerpdata.origin, lerpdata.angles);
+	float scalefactor = e->netstate.scale / 16.0f;
+	if (scalefactor < 0.001f)
+		scalefactor = 1.0f;
+
+	if (scalefactor != 1.0f)
+	{
+		float mscale_matrix[16];
+		ScaleMatrix (mscale_matrix, scalefactor, scalefactor, scalefactor);
+		MatrixMultiply (model_matrix, mscale_matrix);
+	}
 
 	float fovscale = 1.0f;
 	if (e == &cl.viewent && scr_fov.value > 90.f && cl_gun_fovscale.value)
@@ -514,6 +524,16 @@ void R_DrawAliasModel_ShowTris (cb_context_t *cbx, entity_t *e)
 	float model_matrix[16];
 	IdentityMatrix (model_matrix);
 	R_RotateForEntity (model_matrix, lerpdata.origin, lerpdata.angles);
+	float scalefactor = e->netstate.scale / 16.0f;
+	if (scalefactor < 0.001f)
+		scalefactor = 1.0f;
+
+	if (scalefactor != 1.0f)
+	{
+		float mscale_matrix[16];
+		ScaleMatrix (mscale_matrix, scalefactor, scalefactor, scalefactor);
+		MatrixMultiply (model_matrix, mscale_matrix);
+	}
 
 	float fovscale = 1.0f;
 	if (e == &cl.viewent && scr_fov.value > 90.f)

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1886,9 +1886,9 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg)
 
 		// johnfitz -- max size for protocol 15 is 18 bytes, not 16 as originally
 		// assumed here.  And, for protocol 85 the max size is actually 24 bytes.
-		// For float coords and angles the limit is 39.
+		// For float coords and angles the limit is 40.
 		// FIXME: Use tighter limit according to protocol flags and send bits.
-		if (msg->cursize + 39 > maxsize)
+		if (msg->cursize + 40 > maxsize)
 		{
 			// johnfitz -- less spammy overflow message
 			if (!dev_overflows.packetsize || dev_overflows.packetsize + CONSOLE_RESPAM_TIME < realtime)


### PR DESCRIPTION
Add support for models to use `scale` field. Used to scale up or down misc_model decorations such as statues or trees to add variety and emphasis.

This is purely scaling the model drawing. Scales the bounds to prevent the entity becoming invisible when not looking at its origin.

**Test Files**
[scaletest.zip](https://github.com/Novum/vkQuake/files/9245746/scaletest.zip)

Tiny test mod containing a test map maps/test_scale.bsp and a v1.06 progs.dat with only `.float scale;` added to defs.qc
Disregard the fact that this is an enemy model; I'm merely using a func_illusionary to display it and chose a standard id1 model.

Expected results below.  The doubled one in the middle is scale 1.0 (not set).  The unscaled one at the far left is scale set too small.
![image](https://user-images.githubusercontent.com/7354604/182287372-3a31fb55-e69e-4513-a1e7-087bd21fd576.png)