### PR TITLE
Clear center message on game change.

### DIFF
--- a/Quake/cl_demo.c
+++ b/Quake/cl_demo.c
@@ -162,7 +162,7 @@ static int CL_GetDemoMessage (void)
 CL_Seek_f
 ====================
 */
-extern float scr_centertime_off, scr_clock_off;
+extern float scr_clock_off;
 void CL_Seek_f (void)
 {
 	if (cmd_source != src_command)
@@ -207,7 +207,7 @@ void CL_Seek_f (void)
 #ifdef PSET_SCRIPT
 		PScript_ClearParticles ();
 #endif
-		scr_centertime_off = 0;
+		SCR_CenterPrintClear ();
 		cl.intermission = 0;
 		memset (cl.stats, 0, sizeof (cl.stats));
 		memset (cl.statsf, 0, sizeof (cl.statsf));

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2133,6 +2133,8 @@ static void COM_Game_f (void)
 		cls.demonum = -1;
 		Host_ShutdownServer (true);
 
+		SCR_CenterPrintClear ();
+
 		// Write config file
 		Host_WriteConfiguration ();
 

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -150,6 +150,11 @@ int   scr_center_lines;
 int   scr_erase_lines;
 int   scr_erase_center;
 
+void SCR_CenterPrintClear (void)
+{
+	scr_centertime_off = 0;
+}
+
 /*
 ==============
 SCR_CenterPrint
@@ -855,7 +860,8 @@ void SCR_BeginLoadingPlaque (void)
 
 	// redraw with no console and the loading plaque
 	Con_ClearNotify ();
-	scr_centertime_off = scr_clock_off = 0;
+	SCR_CenterPrintClear ();
+	scr_clock_off = 0;
 	scr_con_current = 0;
 
 	scr_drawloading = true;

--- a/Quake/screen.h
+++ b/Quake/screen.h
@@ -30,6 +30,7 @@ void SCR_LoadPics (void);
 
 void SCR_UpdateScreen (qboolean use_tasks);
 
+void SCR_CenterPrintClear (void);
 void SCR_CenterPrint (const char *str);
 
 void SCR_BeginLoadingPlaque (void);

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -2898,7 +2898,7 @@ SV_SpawnServer
 This is called at the start of each level
 ================
 */
-extern float scr_centertime_off, scr_clock_off;
+extern float scr_clock_off;
 void         SV_SpawnServer (const char *server)
 {
 	static char dummy[8] = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -2909,7 +2909,8 @@ void         SV_SpawnServer (const char *server)
 	// let's not have any servers with no name
 	if (hostname.string[0] == 0)
 		Cvar_Set ("hostname", "UNNAMED");
-	scr_centertime_off = scr_clock_off = 0;
+	SCR_CenterPrintClear ();
+	scr_clock_off = 0;
 
 	Con_DPrintf ("SpawnServer: %s\n", server);
 	svs.changelevel_issued = false; // now safe to issue another


### PR DESCRIPTION
How to reproduce: start vkQuake, menu/mods/ad, map start, wait for welcome center screen message, menu/mods/quit - "welcome to arcane dimension" message remains on screen during playback id1/demo1