### PR TITLE
Fix MODS menu PgDn/PgUp/Home/End navigation for single page case

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1726,7 +1726,11 @@ void M_Mods_Key (int key)
 		S_LocalSound ("misc/menu1.wav");
 		prev_mods_cursor = mods_cursor;
 	}
-	first_mod = CLAMP (mods_cursor - MAX_MODS_ON_SCREEN + 1, first_mod, mods_cursor);
+
+	if (num_mods <= MAX_MODS_ON_SCREEN)
+		first_mod = 0;
+	else
+		first_mod = CLAMP (mods_cursor - MAX_MODS_ON_SCREEN + 1, first_mod, mods_cursor);
 }
 
 //=============================================================================


### PR DESCRIPTION
Don't sсroll mods list unless it is necessary.

![vkQuake-mods-pages](https://user-images.githubusercontent.com/6490190/188500457-0dadabd1-67c7-4667-b1a9-0c195e265645.gif)
