### PR TITLE
Fix empty MODS menu navigation

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1720,7 +1720,11 @@ void M_Mods_Key (int key)
 		break;
 	}
 
-	mods_cursor = CLAMP (0, mods_cursor, num_mods - 1);
+	if (num_mods == 0)
+		mods_cursor = 0;
+	else
+		mods_cursor = CLAMP (0, mods_cursor, num_mods - 1);
+
 	if (mods_cursor != prev_mods_cursor)
 	{
 		S_LocalSound ("misc/menu1.wav");


### PR DESCRIPTION
mods_cursor becomes -1 after CLAMP with side effects

remove all mods, start vkQuake, Main Menu, Mods, Down, Up

![vkQuake-mods-zero](https://user-images.githubusercontent.com/6490190/188500616-dc0f518a-be2d-45c1-8d57-49bf374d91ac.gif)
