### PR TITLE
Replace atomics with thread-local variables

### DIFF
--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -30,8 +30,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 float Fog_GetDensity (void);
 void  Fog_GetColor (float *c);
 
-extern atomic_uint32_t rs_skypolys;  // for r_speeds readout
-extern atomic_uint32_t rs_skypasses; // for r_speeds readout
 float                  skyflatcolor[3];
 float                  skymins[2][6], skymaxs[2][6];
 
@@ -608,7 +606,7 @@ void Sky_ProcessPoly (cb_context_t *cbx, glpoly_t *p, float color[3])
 
 	// draw it
 	DrawGLPoly (cbx, p, color, 1.0f);
-	Atomic_IncrementUInt32 (&rs_brushpasses);
+	++thread_counters.rs_brushpasses;
 
 	// update sky bounds
 	if (!r_fastsky.value)
@@ -831,8 +829,8 @@ void Sky_DrawSkyBox (cb_context_t *cbx)
 		R_BindPipeline (cbx, VK_PIPELINE_BIND_POINT_GRAPHICS, vulkan_globals.sky_box_pipeline);
 		vkCmdDrawIndexed (cbx->cb, 6, 1, 0, 0, 0);
 
-		Atomic_IncrementUInt32 (&rs_skypolys);
-		Atomic_IncrementUInt32 (&rs_skypasses);
+		++thread_counters.rs_skypolys;
+		++thread_counters.rs_skypasses;
 	}
 }
 
@@ -923,8 +921,8 @@ void Sky_DrawFaceQuad (cb_context_t *cbx, glpoly_t *p, float alpha)
 	vkCmdBindVertexBuffers (cbx->cb, 0, 1, &vertex_buffer, &vertex_buffer_offset);
 	vkCmdDrawIndexed (cbx->cb, 6, 1, 0, 0, 0);
 
-	Atomic_IncrementUInt32 (&rs_skypolys);
-	Atomic_IncrementUInt32 (&rs_skypasses);
+	++thread_counters.rs_skypolys;
+	++thread_counters.rs_skypasses;
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -378,9 +378,19 @@ extern cvar_t gl_nocolors;
 #define OFFSET_NONE  0
 #define OFFSET_DECAL 1
 
-// johnfitz -- rendering statistics
-extern atomic_uint32_t rs_brushpolys, rs_aliaspolys, rs_skypolys, rs_particles, rs_fogpolys;
-extern atomic_uint32_t rs_dynamiclightmaps, rs_brushpasses, rs_aliaspasses, rs_skypasses;
+typedef struct
+{
+	// johnfitz -- rendering statistics
+	uint32_t rs_brushpolys, rs_aliaspolys, rs_skypolys, rs_particles, rs_fogpolys;
+	uint32_t rs_dynamiclightmaps, rs_brushpasses, rs_aliaspasses, rs_skypasses;
+
+	/* when using GPU lightmap update, bitmap of lightstyles that will be drawn using this lightmap (16..64 OR-folded into bits 16..31) */
+	uint32_t lightmap_modified[MAX_SANITY_LIGHTMAPS]; // must be last for memset clears
+} per_thread_counters;
+
+extern THREAD_LOCAL per_thread_counters thread_counters;
+
+extern per_thread_counters *thread_local_counters[];
 
 extern atomic_uint64_t total_device_vulkan_allocation_size;
 extern atomic_uint64_t total_host_vulkan_allocation_size;
@@ -443,7 +453,6 @@ struct lightmap_s
 	gltexture_t    *surface_indices_texture;
 	gltexture_t    *lightstyle_textures[MAXLIGHTMAPS];
 	VkDescriptorSet descriptor_set;
-	atomic_uint32_t modified; // when using GPU lightmap update, bitmap of lightstyles that will be drawn using this lightmap (16..64 OR-folded into bits 16..31)
 	glRect_t        rectchange;
 	VkBuffer        workgroup_bounds_buffer;
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -143,7 +143,7 @@ static void GL_DrawAliasFrame (
 
 	vulkan_globals.vk_cmd_draw_indexed (cbx->cb, paliashdr->numindexes, 1, 0, 0, 0);
 
-	Atomic_AddUInt32 (&rs_aliaspasses, paliashdr->numtris);
+	thread_counters.rs_aliaspasses += paliashdr->numtris;
 }
 
 /*
@@ -428,7 +428,7 @@ void R_DrawAliasModel (cb_context_t *cbx, entity_t *e)
 	//
 	// set up lighting
 	//
-	Atomic_AddUInt32 (&rs_aliaspolys, paliashdr->numtris);
+	thread_counters.rs_aliaspolys += paliashdr->numtris;
 	vec3_t shadevector, lightcolor;
 	R_SetupAliasLighting (e, &shadevector, &lightcolor);
 

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1013,7 +1013,7 @@ static void R_DrawParticlesFaces (cb_context_t *cbx)
 		vertices[current_vertex].color[3] = 255;
 		current_vertex++;
 
-		Atomic_IncrementUInt32 (&rs_particles);
+		++thread_counters.rs_particles;
 	}
 
 	vulkan_globals.vk_cmd_bind_vertex_buffers (cbx->cb, 0, 1, &vertex_buffer, &vertex_buffer_offset);


### PR DESCRIPTION
On a 6c/12t Skylake this appears to be quite a bit faster in some cases (1.23 -> 1.01ms in alk_dancing start, 12.12 -> 10.81ms in shib8 start, no change in ad_tears).