### PR TITLE
meson.build: create bintoc executable for native

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ shaders = [
 glslang = find_program('glslangValidator')
 spirv_opt = find_program('spirv-opt')
 spirv_remap = find_program('spirv-remap')
-bintoc = executable('bintoc', ['Shaders/bintoc.c'])
+bintoc = executable('bintoc', ['Shaders/bintoc.c'], native: true)
 if (build_machine.system() == 'darwin') or get_option('buildtype').startswith('debug')
     spirv_opt_command = [] # MoltenVK spirv-cross has a bug that breaks optimized shaders
 else


### PR DESCRIPTION
Signed-off-by: Markus Volk <f_l_k@t-online.de>

Hi,
when crosscompiling vkquake with openembedded i had a problem with 'bintoc not found' because it was built for target.