### PR TITLE
Allow exceeding TEXTURE_HEAP_SIZE if necessary

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -934,7 +934,7 @@ static void TexMgr_LoadImage32 (gltexture_t *glt, unsigned *data)
 	vkGetImageMemoryRequirements (vulkan_globals.device, glt->image, &memory_requirements);
 
 	uint32_t     memory_type_index = GL_MemoryTypeFromProperties (memory_requirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0);
-	VkDeviceSize heap_size = TEXTURE_HEAP_SIZE_MB * (VkDeviceSize)1024 * (VkDeviceSize)1024;
+	VkDeviceSize heap_size = q_max (TEXTURE_HEAP_SIZE_MB * (VkDeviceSize)1024 * (VkDeviceSize)1024, memory_requirements.size);
 	VkDeviceSize aligned_offset = GL_AllocateFromHeaps (
 		&num_texmgr_heaps, &texmgr_heaps, heap_size, memory_type_index, VULKAN_MEMORY_TYPE_DEVICE, memory_requirements.size, memory_requirements.alignment,
 		&glt->heap, &glt->heap_node, &num_vulkan_tex_allocations, "Textures Heap");


### PR DESCRIPTION
@novum It turns out there are maps using 6x2Kx2K skies that need 96MB+ by themselves. It's possible to fall back to the old path or downsize them in that case, but this removes the size limitation altogether by allocating a big enough heap for images that wouldn't fit otherwise. Does this seem OK to you?