### PR TITLE
Change config name to vkQuake.cfg

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1564,6 +1564,7 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file, unsigne
 	char          netpath[MAX_OSPATH];
 	pack_t       *pak;
 	int           i;
+	qboolean      is_config = !q_strcasecmp (filename, "config.cfg"), found = false;
 
 	if (file && handle)
 		Sys_Error ("COM_FindFile: both handle and file set");
@@ -1614,9 +1615,19 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file, unsigne
 					continue;
 			}
 
-			q_snprintf (netpath, sizeof (netpath), "%s/%s", search->filename, filename);
-			if (!(Sys_FileType(netpath) & FS_ENT_FILE))
-				continue;
+			if (is_config)
+			{
+				q_snprintf (netpath, sizeof (netpath), "%s/" CONFIG_NAME, search->filename);
+				if (Sys_FileType (netpath) & FS_ENT_FILE)
+					found = true;
+			}
+			
+			if (!found)
+			{
+				q_snprintf (netpath, sizeof (netpath), "%s/%s", search->filename, filename);
+				if (!(Sys_FileType (netpath) & FS_ENT_FILE))
+					continue;
+			}
 
 			if (path_id)
 				*path_id = search->path_id;

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -345,10 +345,10 @@ void Host_WriteConfiguration (void)
 			SDL_free (pref_path);
 		}
 		else
-			f = fopen (va ("%s/config.cfg", com_gamedir), "w");
+			f = fopen (va ("%s/" CONFIG_NAME, com_gamedir), "w");
 		if (!f)
 		{
-			Con_Printf ("Couldn't write config.cfg.\n");
+			Con_Printf ("Couldn't write " CONFIG_NAME ".\n");
 			return;
 		}
 

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -64,6 +64,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	" " VKQUAKE_VER_STRING
 #endif
 
+#define CONFIG_NAME "vkQuake.cfg"
+
 // define	PARANOID			// speed sapping error checking
 
 #define GAMENAME "id1" // directory to look in by default


### PR DESCRIPTION
This changes the name of the non-multiuser config to `vkQuake.cfg`, since configs are not really compatible between engines and (graphics) settings will get reset if switching back and forth.

This is done in `COM_FindFile ()` so that:
* it works with existing scripts (`config.cfg` is usually executed from `quake.rc` which is part of the mod, not the engine)
* it respects search path priority, so a `config.cfg` in the mod folder will have higher priority than a `vkQuake.cfg` in `id1` (this is so per-mod configs are not reset the first time if `id1\vkQuake.cfg` was written first)