### PR TITLE
[CI] Put platform in built artifact name to prevent overwriting

### DIFF
--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Upload vkQuake
       uses: actions/upload-artifact@v3
       with:
-        name: vkQuake archive
+        name: vkQuake archive (${{ matrix.platform.msystem }})
         path: |
             Quake/*.exe
             Quake/*.dll

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Upload vkQuake
       uses: actions/upload-artifact@v3
       with:
-        name: vkQuake archive
+        name: vkQuake archive (${{ matrix.configuration }}, ${{ matrix.platform }})
         path: |
             Windows\VisualStudio\Build-vkQuake\**\*.exe
             Windows\VisualStudio\Build-vkQuake\**\*.dll


### PR DESCRIPTION
Github Action artifacts are namespaced by workflow, so workflows that have multiple jobs that each upload an artifact with the same name will trample over each other. The build-mingw and build-windows workflows use multiple jobs for creating 32 bit and 64 bit executables, but then name the artifacts the same, causing only one set of artifacts to be retrievable per workflow. This PR makes it so each job gives a descriptive name to its own artifacts.