### PR TITLE
Meson build: Support ARM Macs by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,7 @@ deps = [
 ]
 
 if build_machine.system() == 'darwin'
-    deps += cc.find_library('MoltenVK', required : true)
+    deps += cc.find_library('MoltenVK', required : true, dirs : ['/opt/homebrew/lib'])
 else
     deps += dependency('vulkan')
 endif

--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,11 @@ deps = [
 ]
 
 if build_machine.system() == 'darwin'
-    deps += cc.find_library('MoltenVK', required : true, dirs : ['/opt/homebrew/lib'])
+    molten_dirs = []
+    if import('fs').exists('/opt/homebrew/lib/libMoltenVK.dylib')
+        molten_dirs += '/opt/homebrew/lib'
+    endif
+    deps += cc.find_library('MoltenVK', required : true, dirs : molten_dirs)
 else
     deps += dependency('vulkan')
 endif

--- a/readme.md
+++ b/readme.md
@@ -123,12 +123,6 @@ cd vkQuake
 meson build && ninja -C build
 ~~~
 
-> 📝 **Note**: On ARM macs the default homebrew installation moved to `/opt/homebrew`. For meson to be able to find homebrew files you need to set the following environment:
-> ```
-> $ export PATH=/opt/homebrew/bin:$PATH
-> $ export LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH
-> $ export CPATH=/opt/homebrew/include:$CPATH
-> ```
 > 📝 **Note**: The Meson version needs to be 0.47.0 or newer.
 
 ### MinGW


### PR DESCRIPTION
This PR makes it so that the Mac build instructions of `meson build && ninja -C build` just work even on modern ARM Macs where Homebrew installs libraries to `/opt/homebrew/lib`. This makes the extra instructions in the readme for ARM Macs unnecessary. The build still works for non-ARM Macs too.

(Only the `cc.find_library()` call for MoltenVK had to be changed. It was the only `cc.find_library()` call for a brew-installed dependency. The other brew-installed dependencies were found through the `dependency()` function, which I think is able to find brew-installed libraries by default.)

This is basically the same change I made to the [Makefile](https://github.com/Novum/vkQuake/pull/330/files#diff-9b00d1a32e360c0662d3221add6af44af67bfa593236b39c8926da6f522e2f41R155) in https://github.com/Novum/vkQuake/pull/330 redone for the new Meson build script.