### PR TITLE
Fix controller A+B button support in video options menu

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -3652,6 +3652,7 @@ static void VID_MenuKey (int key)
 	{
 	case K_MOUSE2:
 	case K_ESCAPE:
+	case K_BBUTTON:
 		VID_SyncCvars (); // sync cvars before leaving menu. FIXME: there are other ways to leave menu
 		S_LocalSound ("misc/menu1.wav");
 		M_Menu_Options_f ();
@@ -3770,6 +3771,7 @@ static void VID_MenuKey (int key)
 	case K_MOUSE1:
 	case K_ENTER:
 	case K_KP_ENTER:
+	case K_ABUTTON:
 		m_entersound = true;
 		switch (video_options_cursor)
 		{


### PR DESCRIPTION
The video options menu specifically didn't support a controller's A+B buttons, making the menu unusable from a controller. All other menus worked fine.

This PR fixes this. This PR makes this part of the code consistent with QuakeSpasm. With this change, everywhere that handles K_ENTER/K_KP_ENTER (outside of console, multiplayer chat, and alt+enter handling) also handles A button presses, and most spots that handle K_ESCAPE handle B button presses too (escape does have a little special handling in some places so I don't expect 1:1 matching there).