### PR TITLE
[CI]: Make docker build use github actions cache

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -9,11 +9,21 @@ on:
 jobs:
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Build Docker image
-      run: docker build . --file Packaging/AppImage/docker/Dockerfile --tag build-vkquake
+      uses: docker/build-push-action@v4
+      with:
+        context: Packaging/AppImage/docker
+        platforms: linux/amd64
+        tags: build-vkquake
+        load: true
+        push: false
+        cache-from: type=gha
+        cache-to: type=gha
     - name: Build vkQuake
       run: docker run --rm --privileged -e VERSION=${GITHUB_SHA::8} -v ${PWD}:/usr/src/vkQuake build-vkquake /usr/src/vkQuake/Packaging/AppImage/run-in-docker.sh
     - name: Upload vkQuake


### PR DESCRIPTION
Background context: The build-linux.yml Github Actions Workflow builds a docker image containing the vkQuake AppImage build dependencies (including apt installing many things and compiling SDL) and then uses it to build a vkQuake AppImage. The docker build step [usually takes 3-5 minutes](https://github.com/Novum/vkQuake/actions/runs/4109309987), though in the last few days on my own fork I've seen it often take [8-45 minutes](https://github.com/Macil/vkQuake/actions/runs/4101294049) or even failing because of the apt install processes having temporary connection issues to the Ubuntu package repos.

The goal of this PR is to both shave off some time in the usual case, and to make it much less likely for people to experience unusually slow or failing docker builds by preventing most builds from being necessary.

This PR makes the docker image be cached into the Github Actions cache. If the docker image is found in the cache, then it's loaded from there instead of being built. (The actual vkQuake compilation is not cached and always happens.) [In this commit, it took 45 seconds to load from cache](https://github.com/Macil/vkQuake/actions/runs/4110019747/jobs/7092445864). However, if the image isn't found in the cache, the build step takes a little longer as it has to save it to the cache now (the build took [5m13s in this commit](https://github.com/Macil/vkQuake/actions/runs/4109976191/jobs/7092356131), [4m19s in this PR's commit](https://github.com/Novum/vkQuake/actions/runs/4110524152/jobs/7093432129)), but this should be uncommon and still lead to net time savings.

The diff is pretty straight-forward: the PR uses the official [Docker build-push-action Github Action](https://github.com/marketplace/actions/build-and-push-docker-images) to run the docker build with GitHub Actions caching support turned on. The action is configured in a way that's equivalent to the old `docker build` command except with caching being supported. No manual cache invalidation needs to be done on future changes to the Dockerfile or any other configuration; docker will only use cached results if they use the same inputs as it's using now, and it's even smart enough to load cached results of any previous untouched steps of the Dockerfile if the Dockerfile is modified.

Nothing inside of the docker image is changed by this PR. The docker image produced by this PR will still be equivalent to the one produced previously. I did update the github action itself to run on Ubuntu 22.04, but the docker image itself still runs Ubuntu 18.04 and produces AppImages compatible with Ubuntu 18.04. (I did consider updating the docker image itself to run Ubuntu 22.04 just to update everything while I was looking at it, but I found that doing that made the vkQuake AppImage no longer compatible with Ubuntu 18.04, which might not be desirable and wouldn't be good to combine with this PR anyway.)