### PR TITLE
Fix QuakeC multicasting extension

### DIFF
--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -1570,6 +1570,10 @@ sizebuf_t *WriteDest (void)
 	case MSG_INIT:
 		return &sv.signon;
 
+	case MSG_EXT_MULTICAST:
+	case MSG_EXT_ENTITY: // just reuse it...
+		return &sv.multicast;
+
 	default:
 		PR_RunError ("WriteDest: bad destination");
 		break;


### PR DESCRIPTION
vkQuake, trough checkextension, reports to the QuakeC that it supports `FTE_QC_MULTICAST`, yet trying to write a message to MSG_MULTICAST throws an error. Looks like it has the Quakespasm-spiked code for sending multicast messages but WriteDest in pr_cmds.c was never edited to allow MSG_MULTICAST write calls. The new switch cases are directly copied from QSS