### PR TITLE
Best-effort alpha sorting

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -57,8 +57,11 @@ lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
 dlight_t		cl_dlights[MAX_DLIGHTS];
 
 int		   cl_numvisedicts;
+int		   cl_numvisedicts_alpha_overwater;
+int		   cl_numvisedicts_alpha_underwater;
 int		   cl_maxvisedicts;
 entity_t **cl_visedicts;
+entity_t **cl_visedicts_alpha;
 
 extern cvar_t r_lerpmodels, r_lerpmove; // johnfitz
 extern float  host_netinterval;			// Spike
@@ -635,10 +638,11 @@ void CL_RelinkEntities (void)
 	if (frametime > 0.1)
 		frametime = 0.1;
 
-	if (cl_numvisedicts + 64 > cl_maxvisedicts)
+	if (cl_numvisedicts + 256 > cl_maxvisedicts)
 	{
-		cl_maxvisedicts = cl_maxvisedicts + 64;
+		cl_maxvisedicts += cl_maxvisedicts ? 256 : 4096;
 		cl_visedicts = Mem_Realloc (cl_visedicts, sizeof (*cl_visedicts) * cl_maxvisedicts);
+		cl_visedicts_alpha = Mem_Realloc (cl_visedicts_alpha, sizeof (*cl_visedicts_alpha) * cl_maxvisedicts);
 	}
 	cl_numvisedicts = 0;
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -332,7 +332,10 @@ extern dlight_t		cl_dlights[MAX_DLIGHTS];
 extern entity_t		cl_temp_entities[MAX_TEMP_ENTITIES];
 extern beam_t		cl_beams[MAX_BEAMS];
 extern entity_t	  **cl_visedicts;
+extern entity_t	  **cl_visedicts_alpha;
 extern int			cl_numvisedicts;
+extern int			cl_numvisedicts_alpha_overwater;
+extern int			cl_numvisedicts_alpha_underwater;
 extern int			cl_maxvisedicts; // extended if we exceeded it the previous frame
 
 //=============================================================================

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -88,6 +88,7 @@ typedef enum
 	chain_model_3,
 	chain_model_4,
 	chain_model_5,
+	chain_alpha_model_across_water,
 	chain_alpha_model,
 	chain_num,
 } texchain_t;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -49,6 +49,7 @@ extern cvar_t r_lerpmove;
 extern cvar_t r_nolerp_list;
 // johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
+extern cvar_t r_alphasort;
 
 extern cvar_t r_gpulightmapupdate;
 extern cvar_t r_rtshadows;
@@ -3580,6 +3581,7 @@ void R_Init (void)
 	Cvar_SetCallback (&r_simd, R_SIMD_f);
 	R_SIMD_f (&r_simd);
 #endif
+	Cvar_RegisterVariable (&r_alphasort);
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
 	Cvar_RegisterVariable (&gl_polyblend);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -192,7 +192,9 @@ typedef enum
 	// Main render pass:
 	SCBX_WORLD,
 	SCBX_ENTITIES,
-	SCBX_SKY_AND_WATER,
+	SCBX_SKY,
+	SCBX_ALPHA_ENTITIES_ACROSS_WATER,
+	SCBX_WATER,
 	SCBX_ALPHA_ENTITIES,
 	SCBX_PARTICLES,
 	SCBX_VIEW_MODEL,
@@ -205,7 +207,9 @@ typedef enum
 static const int SECONDARY_CB_MULTIPLICITY[SCBX_NUM] = {
 	NUM_WORLD_CBX,	  // SCBX_WORLD,
 	NUM_ENTITIES_CBX, // SCBX_ENTITIES,
-	1,				  // SCBX_SKY_AND_WATER,
+	1,				  // SCBX_SKY,
+	1,				  // SCBX_ALPHA_ENTITIES_ACROSS_WATER,
+	1,				  // SCBX_WATER,
 	1,				  // SCBX_ALPHA_ENTITIES,
 	1,				  // SCBX_PARTICLES,
 	1,				  // SCBX_VIEW_MODEL,
@@ -558,7 +562,7 @@ qboolean R_IndirectBrush (entity_t *e);
 
 void R_DrawWorld (cb_context_t *cbx, int index);
 void R_DrawAliasModel (cb_context_t *cbx, entity_t *e, int *aliaspolys);
-void R_DrawBrushModel (cb_context_t *cbx, entity_t *e, int chain, int *brushpolys, qboolean water_opaque_only, qboolean water_transparent_only);
+void R_DrawBrushModel (cb_context_t *cbx, entity_t *e, int chain, int *brushpolys, qboolean sort, qboolean water_opaque_only, qboolean water_transparent_only);
 void R_DrawSpriteModel (cb_context_t *cbx, entity_t *e);
 void R_DrawIndirectBrushes (cb_context_t *cbx, qboolean draw_water, qboolean draw_sky, int index);
 void R_DrawIndirectBrushes_ShowTris (cb_context_t *cbx);

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -116,6 +116,9 @@ typedef struct entity_s
 	vec3_t trailorg;   // previous particle trail point
 
 	lightcache_t lightcache; // alias light trace cache
+
+	int	   contentscache;
+	vec3_t contentscache_origin;
 } entity_t;
 
 // !!! if this is changed, it must be changed in asm_draw.h too !!!


### PR DESCRIPTION
Potential fix for #631

This implements transparency sorting, using 3 methods:

* Alpha entities are classified as underwater or overwater according to their center, and drawn before or after the water (this also helps many other levels when underwater, as it avoids transparents over the water surface getting drawn after the water)
* Alpha entities are sorted back to front by their closest point (view angle independent)
* Transparent brush model surfs are chained in depth order using BSP traversal. This gives perfect ordering within a model for cheap (as long as it uses a single texture as implemented, since it doesn't flush on texture changes). D2M6 needs this because several crystals and waterfalls are grouped as a single entity.

This is not exhaustive but solves all sorting problems I can see in D2M6 (except a few subtle ones caused by the opaque water used as a ceiling - this is fixable but I'm not sure it's worth it) and a few other levels.