### PR TITLE
Fix menu cursor movement

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -3705,6 +3705,8 @@ void M_Video_Key (int key)
 	case K_UPARROW:
 		S_LocalSound ("misc/menu1.wav");
 		video_options_cursor--;
+		if (video_options_cursor == VID_OPT_PADDING)
+			video_options_cursor--;
 		if (video_options_cursor < 0)
 			video_options_cursor = VIDEO_OPTIONS_ITEMS - 1;
 		break;
@@ -3712,6 +3714,8 @@ void M_Video_Key (int key)
 	case K_DOWNARROW:
 		S_LocalSound ("misc/menu1.wav");
 		video_options_cursor++;
+		if (video_options_cursor == VID_OPT_PADDING)
+			video_options_cursor++;
 		if (video_options_cursor >= VIDEO_OPTIONS_ITEMS)
 			video_options_cursor = 0;
 		break;
@@ -3844,7 +3848,7 @@ void M_Video_Draw (cb_context_t *cbx)
 
 		M_Mouse_UpdateCursor (&video_options_cursor, 12, 400, y, 8, i);
 		if (video_options_cursor == VID_OPT_PADDING)
-			video_options_cursor = VID_OPT_VSYNC;
+			video_options_cursor--;
 		if (video_options_cursor == i)
 			Draw_Character (cbx, MENU_CURSOR_X, y, 12 + ((int)(realtime * 4) & 1));
 

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -2070,7 +2070,7 @@ static void M_Options_Draw (cb_context_t *cbx)
 	// cursor
 	M_Mouse_UpdateListCursor (&options_cursor, MENU_LABEL_X, 320, top, CHARACTER_SIZE, OPTIONS_ITEMS, 0);
 	if (options_cursor == OPT_PADDING)
-		options_cursor = OPT_SOUND;
+		options_cursor--;
 	Draw_Character (cbx, MENU_CURSOR_X, top + options_cursor * CHARACTER_SIZE, 12 + ((int)(realtime * 4) & 1));
 }
 
@@ -2123,6 +2123,8 @@ void M_Options_Key (int k)
 	case K_UPARROW:
 		S_LocalSound ("misc/menu1.wav");
 		options_cursor--;
+		if (options_cursor == OPT_PADDING)
+			options_cursor--;
 		if (options_cursor < 0)
 			options_cursor = OPTIONS_ITEMS - 1;
 		break;
@@ -2130,6 +2132,8 @@ void M_Options_Key (int k)
 	case K_DOWNARROW:
 		S_LocalSound ("misc/menu1.wav");
 		options_cursor++;
+		if (options_cursor == OPT_PADDING)
+			options_cursor++;
 		if (options_cursor >= OPTIONS_ITEMS)
 			options_cursor = 0;
 		break;

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1978,13 +1978,13 @@ static void M_SoundOptions_Key (int k)
 		S_LocalSound ("misc/menu1.wav");
 		sound_options_cursor--;
 		if (sound_options_cursor < 0)
-			sound_options_cursor = GAME_OPTIONS_ITEMS - 1;
+			sound_options_cursor = SOUND_OPTIONS_ITEMS - 1;
 		break;
 
 	case K_DOWNARROW:
 		S_LocalSound ("misc/menu1.wav");
 		sound_options_cursor++;
-		if (sound_options_cursor >= GAME_OPTIONS_ITEMS)
+		if (sound_options_cursor >= SOUND_OPTIONS_ITEMS)
 			sound_options_cursor = 0;
 		break;
 


### PR DESCRIPTION
This fixes two issues:
1. The cursor in the sound menu can be moved too far with the arrow keys.
2. The cursor could not be moved with the down key past the padding gap in the options menu or the video menu.

(not related to the issue I opened previously about mouse cursor stuff)