### PR TITLE
Replace "Screen Size" slider with "Interface Detail" no-gun/none/standard/full option

### DIFF
--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -94,6 +94,7 @@ cvar_t scr_usekfont = {"scr_usekfont", "0", CVAR_NONE}; // 2021 re-release
 cvar_t scr_style = {"scr_style", "0", CVAR_ARCHIVE};
 
 cvar_t scr_viewsize = {"viewsize", "100", CVAR_ARCHIVE};
+cvar_t scr_viewsize_allow_shrinking = {"viewsize_allow_shrinking", "0", CVAR_ARCHIVE};
 cvar_t scr_fov = {"fov", "90", CVAR_ARCHIVE}; // 10 - 170
 cvar_t scr_fov_adapt = {"fov_adapt", "1", CVAR_ARCHIVE};
 cvar_t scr_zoomfov = {"zoom_fov", "30", CVAR_ARCHIVE}; // 10 - 170
@@ -442,7 +443,10 @@ Keybinding command
 */
 void SCR_SizeDown_f (void)
 {
-	Cvar_SetValueQuick (&scr_viewsize, scr_viewsize.value - 10);
+	float new_value = scr_viewsize.value - 10;
+	if (!scr_viewsize_allow_shrinking.value)
+		new_value = q_max (new_value, 100);
+	Cvar_SetValueQuick (&scr_viewsize, new_value);
 }
 
 static void SCR_Callback_refdef (cvar_t *var)
@@ -561,6 +565,7 @@ void SCR_Init (void)
 	Cvar_RegisterVariable (&scr_zoomfov);
 	Cvar_RegisterVariable (&scr_zoomspeed);
 	Cvar_RegisterVariable (&scr_viewsize);
+	Cvar_RegisterVariable (&scr_viewsize_allow_shrinking);
 	Cvar_RegisterVariable (&scr_conspeed);
 	Cvar_RegisterVariable (&scr_conanim);
 	Cvar_RegisterVariable (&scr_showturtle);

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1331,7 +1331,6 @@ static void M_Net_Key (int k)
 enum
 {
 	GAME_OPT_SCALE,
-	GAME_OPT_SCRSIZE,
 	GAME_OPT_SBALPHA,
 	GAME_OPT_MOUSESPEED,
 	GAME_OPT_VIEWBOB,
@@ -1342,6 +1341,7 @@ enum
 	GAME_OPT_ALWAYSMLOOK,
 	GAME_OPT_LOOKSPRING,
 	GAME_OPT_LOOKSTRAFE,
+	GAME_OPT_SCRSIZE,
 	GAME_OPT_SCRSTYLE,
 	GAME_OPT_CROSSHAIR,
 	GAME_OPT_AUTOLOAD,
@@ -1389,10 +1389,6 @@ static void M_GameOptions_AdjustSliders (int dir, qboolean mouse)
 			Cvar_SetValue ("scr_sbarscale", f);
 		}
 		break;
-	case GAME_OPT_SCRSIZE: // screen size
-		f = M_GetSliderPos (30, 130, scr_viewsize.value, false, mouse, clamped_mouse, dir, 10, 100);
-		Cvar_SetValue ("viewsize", f);
-		break;
 	case GAME_OPT_MOUSESPEED: // mouse speed
 		f = M_GetSliderPos (1, 11, sensitivity.value, false, mouse, clamped_mouse, dir, 0.5, 999);
 		Cvar_SetValue ("sensitivity", f);
@@ -1437,6 +1433,10 @@ static void M_GameOptions_AdjustSliders (int dir, qboolean mouse)
 		break;
 	case GAME_OPT_CROSSHAIR:
 		Cvar_SetValue ("crosshair", ((int)crosshair.value + 3 + dir) % 3);
+		break;
+	case GAME_OPT_SCRSIZE: // interface detail
+		// cycles through 130 (no gun), 120 (none), 110 (standard), 100 (full)
+		Cvar_SetValue ("viewsize", (CLAMP (0, ((int)scr_viewsize.value - 100) / 10, 3) + 4 - dir) % 4 * 10 + 100);
 		break;
 	case GAME_OPT_SCRSTYLE:
 		Cvar_SetValue ("scr_style", ((int)scr_style.value + 3 + dir) % 3);
@@ -1511,10 +1511,6 @@ static void M_GameOptions_Draw (cb_context_t *cbx)
 	r = l > 0 ? ((scr_relativescale.value ? scr_relativescale.value : scr_conscale.value) - 1) / l : 0;
 	M_DrawSlider (cbx, MENU_SLIDER_X, top + CHARACTER_SIZE * GAME_OPT_SCALE, r);
 
-	M_Print (cbx, MENU_LABEL_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "Screen Size");
-	r = (scr_viewsize.value - 30) / (130 - 30);
-	M_DrawSlider (cbx, MENU_SLIDER_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, r);
-
 	M_Print (cbx, MENU_LABEL_X, top + CHARACTER_SIZE * GAME_OPT_SBALPHA, "Statusbar Alpha");
 	r = (1.0 - scr_sbaralpha.value); // scr_sbaralpha range is 1.0 to 0.0
 	M_DrawSlider (cbx, MENU_SLIDER_X, top + CHARACTER_SIZE * GAME_OPT_SBALPHA, r);
@@ -1548,6 +1544,16 @@ static void M_GameOptions_Draw (cb_context_t *cbx)
 
 	M_Print (cbx, MENU_LABEL_X, top + CHARACTER_SIZE * GAME_OPT_LOOKSTRAFE, "Lookstrafe");
 	M_DrawCheckbox (cbx, MENU_VALUE_X, top + CHARACTER_SIZE * GAME_OPT_LOOKSTRAFE, lookstrafe.value);
+
+	M_Print (cbx, MENU_LABEL_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "Interface Detail");
+	if (scr_viewsize.value >= 130.0f)
+		M_Print (cbx, MENU_VALUE_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "No gun");
+	else if (scr_viewsize.value >= 120.0f)
+		M_Print (cbx, MENU_VALUE_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "None");
+	else if (scr_viewsize.value >= 110.0f)
+		M_Print (cbx, MENU_VALUE_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "Standard");
+	else
+		M_Print (cbx, MENU_VALUE_X, top + CHARACTER_SIZE * GAME_OPT_SCRSIZE, "Full");
 
 	M_Print (cbx, MENU_LABEL_X, top + CHARACTER_SIZE * GAME_OPT_SCRSTYLE, "Interface Style");
 	if (scr_style.value < 1.0f)


### PR DESCRIPTION
This PR replaces the game options menu "Screen Size" slider with an "Interface Detail" setting that has "No gun"/"None"/"Standard"/"Full" options. This is done to make these HUD settings more discoverable to users who might not expect that a specific section of a slider toggles HUD elements, and to be more familiar with people used to the Kex port. (I honestly had no idea that the "No gun" and "None" behaviors were supported in the Screen Size slider! I thought I had tried the slider fully in the past and never explored its whole range for surprises again.) This is inspired by the Kex port which has a "HUD Style" setting with "Off"/"Minimal"/"Standard"/"Full" options. (This PR doesn't exactly match that setup because "HUD Style" is too close to the naming of the existing "Interface Style" option here, and also "Interface Style" already has a "simple" option that accomplishes what Kex's HUD Style "minimal" value does.)

This PR does sacrifice the ability to shrink the viewport through the options menu, though the whole range of viewsize settings is still supported through the console. My assumption is that this feature isn't commonly purposefully used, and that it was more useful in the distant past before windowed mode was supported and you wanted to save performance by shrinking the resolution to a very small value without affecting the HUD. (The Kex port lacks this feature.)

Additionally, the "-" sizedown key is changed so that it only shrinks the HUD but can't go as far as shrinking the viewport. It seemed wrong to me to let a default keybind set setting values that aren't available in the options menu. This behavior can be overridden by setting "viewsize_allow_shrinking 1".

This PR is a bit of an opinionated change. I would understand if you weren't interested in it. Let me know if you might instead accept a PR that split the "Interface Detail" setting to its own CVAR so that it could exist simultaneously in the options menu alongside the existing "Screen Size" slider, which would be stripped of its statusbar-affecting behavior.