### PR TITLE
Make vq_pak's Makefile update embedded_pak.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.suo
 vkquake.VC*
-Misc/vq_pak/vkquake.pak
 Quake/*.dll
 Quake/*.o
 Quake/*.d
@@ -25,6 +24,8 @@ Packaging/AppImage/vkquake*
 Packaging/Windows/vkQuake-Installer-*.exe
 Packaging/Windows/vkQuake*.zip
 Misc/vq_pak/mkpak
+Misc/vq_pak/bintoc
+Misc/vq_pak/*.dSYM
 build/
 .settings
 .project

--- a/Misc/vq_pak/Makefile
+++ b/Misc/vq_pak/Makefile
@@ -11,13 +11,26 @@ INPUT := gfx/conback.lmp \
 	maps/r2m3@76ec.ent \
 	default.cfg
 
-OUTPUT := vkquake.pak
+OUTPUT_NAME := vkquake.pak
+OUTPUT := ../../Quake/$(OUTPUT_NAME)
+OUTPUT_EMBEDDED := ../../Quake/embedded_pak.c
 
-$(OUTPUT): $(INPUT)
-	cc mkpak.c -o mkpak --std=gnu11 -g && ./mkpak $(OUTPUT) $(INPUT) && zopfli --deflate $(OUTPUT)
+$(OUTPUT_EMBEDDED): bintoc $(OUTPUT) $(OUTPUT).deflate
+	./bintoc $(OUTPUT) $(OUTPUT_NAME) $(OUTPUT_EMBEDDED)
+
+$(OUTPUT).deflate: $(OUTPUT)
+	zopfli --deflate $(OUTPUT)
+
+$(OUTPUT): mkpak $(INPUT)
+	./mkpak $(OUTPUT) $(INPUT)
+
+mkpak: mkpak.c
+	cc mkpak.c -o mkpak --std=gnu11 -g
+
+bintoc: ../../Shaders/bintoc.c
+	cc ../../Shaders/bintoc.c -o bintoc --std=gnu11 -g
 
 .PHONY: clean
 clean:
-	rm -f $(OUTPUT)
 	rm -f mkpak
-
+	rm -f bintoc


### PR DESCRIPTION
While working on MacOS, it took me a while to figure out how I could update vkquake.pak correctly. (I don't have any PRs planned that update vkquake.pak. I'm just experimenting with it in my own fork.) I eventually figured out it was a multi-step process: run `make` in the Misc/vq_pak directory, move both vkquake.pak and vkquake.pak.deflate to the Quake folder, and then use bintoc from the build directory to make a new embedded_pak.c file. The third step was automated inside of the Visual Studio project but not in any of the other platforms' build scripts.

This PR streamlines things by making Misc/vq_pak's Makefile produce embedded_pak.c directly in the proper place, killing steps 2 and 3. The third step in the VS project config and the committed copies of vkquake.pak and vkquake.pak.deflate are removed. (I made the change through Visual Studio and made sure the build still worked.)

The vq_pak Makefile does compile its own bintoc copy now. It was a bit convenient before that when the third step was in the (VS) build configuration it could easily use the same bintoc copy used for shaders, but even with this change the vq_pak Makefile is still very simple and I think the streamlining of this PR outweighs that small downside.

(Also fixes a minor issue where vq_pak's Makefile didn't specify vkquake.pak.deflate as a target, so if you previously created vkquake.pak but failed to create vkquake.pak.deflate (like because zopfli wasn't installed), then running `make` again would end immediately instead of creating vkquake.pak.deflate.)