### PR TITLE
Make HUD detail setting respect left/right keys

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1447,11 +1447,11 @@ static void M_GameOptions_AdjustSliders (int dir, qboolean mouse)
 	case GAME_OPT_HUD_DETAIL: // interface detail
 		// cycles through 120 (none), 110 (standard), 100 (full)
 		if (scr_viewsize.value <= 100.0f)
-			Cvar_SetValue ("viewsize", 110.0f);
+			Cvar_SetValue ("viewsize", dir < 0 ? 110.0f : 120.0f);
 		else if (scr_viewsize.value <= 110.0f)
-			Cvar_SetValue ("viewsize", 120.0f);
+			Cvar_SetValue ("viewsize", dir < 0 ? 120.0f : 100.0f);
 		else
-			Cvar_SetValue ("viewsize", 100.0f);
+			Cvar_SetValue ("viewsize", dir < 0 ? 100.0f : 110.0f);
 		break;
 	case GAME_OPT_HUD_STYLE:
 		Cvar_SetValue ("scr_style", ((int)scr_style.value + 3 + dir) % 3);


### PR DESCRIPTION
Small PR this time. Some of the changes to the HUD detail setting broke support for the left/right keys scrolling through the options in different directions, and this PR fixes that. Pressing left cycles through the options in decreasing HUD elements order and pressing right increases HUD elements, and if you press left then right you will correctly end up back on the same option.

Alternative mathy solution based on my previous one-liner but split up a bit to be slightly more clear: https://github.com/Macil/vkQuake/commit/66c5ad5d37f29f2ce42882286846304acbac34a0. For this few options I don't have a real preference.