### PR TITLE
Fix on-screen keyboard showing up unnecessarily on Steam Deck

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -941,7 +941,8 @@ void IN_SendKeyEvents (void)
 			// are based on key position, not the label on the key cap.
 			key = IN_SDL2_ScancodeToQuakeKey (event.key.keysym.scancode);
 
-			Key_Event (key, down);
+			// though we also pass along the key using the proper current layout for Y/N prompts
+			Key_EventWithKeycode (key, down, event.key.keysym.sym);
 			break;
 
 		case SDL_MOUSEBUTTONDOWN:

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -1192,9 +1192,10 @@ qboolean Key_TextEntry (void)
 	case key_menu:
 		return M_TextEntry ();
 	case key_game:
-		if (!con_forcedup)
-			return false;
-		/* fallthrough */
+		// Don't return true even during con_forcedup, because that happens while starting a
+		// game and we don't to trigger text input (and the onscreen keyboard on some devices)
+		// during this.
+		return false;
 	case key_console:
 		return true;
 	default:

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -969,6 +969,21 @@ Should NOT be called during an interrupt!
 */
 void Key_Event (int key, qboolean down)
 {
+	Key_EventWithKeycode (key, down, 0);
+}
+
+/*
+===================
+Key_EventWithKeycode
+
+Called by the system between frames for both key up and key down events
+Should NOT be called during an interrupt!
+keycode parameter should have the key's actual keycode using the current keyboard layout,
+not the US-keyboard-based scancode. Pass 0 if not applicable.
+===================
+*/
+void Key_EventWithKeycode (int key, qboolean down, int keycode)
+{
 	char *kb;
 	char  cmd[1024];
 
@@ -1001,7 +1016,11 @@ void Key_Event (int key, qboolean down)
 	if (key_inputgrab.active)
 	{
 		if (down)
+		{
 			key_inputgrab.lastkey = key;
+			if (keycode > 0)
+				key_inputgrab.lastchar = keycode;
+		}
 		return;
 	}
 
@@ -1183,7 +1202,11 @@ Key_TextEntry
 qboolean Key_TextEntry (void)
 {
 	if (key_inputgrab.active)
-		return true;
+	{
+		// This path is used for simple single-letter inputs (y/n prompts) that also
+		// accept controller input, so we don't want an onscreen keyboard for this case.
+		return false;
+	}
 
 	switch (key_dest)
 	{

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -1208,6 +1208,11 @@ qboolean Key_TextEntry (void)
 		return false;
 	}
 
+	// key_dest == key_console for a moment while quitting. Don't let that
+	// cause SDL_StartTextInput.
+	if (m_is_quitting)
+		return false;
+
 	switch (key_dest)
 	{
 	case key_message:

--- a/Quake/keys.h
+++ b/Quake/keys.h
@@ -188,6 +188,7 @@ void Key_EndInputGrab (void);
 void Key_GetGrabbedInput (int *lastkey, int *lastchar);
 
 void	 Key_Event (int key, qboolean down);
+void	 Key_EventWithKeycode (int key, qboolean down, int keycode);
 void	 Char_Event (int key);
 qboolean Key_TextEntry (void);
 

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -80,6 +80,8 @@ qboolean m_entersound; // play after drawing a frame, so caching
 					   // won't disrupt the sound
 qboolean m_recursiveDraw;
 
+qboolean m_is_quitting = false; // prevents SDL_StartTextInput during quit
+
 enum m_state_e m_return_state;
 qboolean	   m_return_onerror;
 char		   m_return_reason[32];
@@ -2577,6 +2579,7 @@ static void M_Quit_Char (int key)
 
 	case 'y':
 	case 'Y':
+		m_is_quitting = true;
 		IN_Deactivate (true);
 		key_dest = key_console;
 		Cbuf_InsertText ("quit");
@@ -3592,6 +3595,7 @@ void M_Draw (cb_context_t *cbx)
 		if (!fitzmode)
 		{ /* QuakeSpasm customization: */
 			/* Quit now! S.A. */
+			m_is_quitting = true;
 			key_dest = key_console;
 			Cbuf_InsertText ("quit");
 		}

--- a/Quake/menu.h
+++ b/Quake/menu.h
@@ -53,6 +53,8 @@ extern enum m_state_e m_return_state;
 
 extern qboolean m_entersound;
 
+extern qboolean m_is_quitting;
+
 //
 // menus
 //


### PR DESCRIPTION
See the upstream PR https://github.com/sezero/quakespasm/pull/54 for full description.

The first two commits of this PR are identical to the upstream QS PR, but then there's an added third [commit](https://github.com/Macil/vkQuake/commit/beca8b6a6cecf665dbddfa3b84dde29c2c901b5e) here to prevent vkQuake spawning an on-screen keyboard as it closes because of a [difference](https://github.com/Novum/vkQuake/commit/f0fbf0f73a79744f7f92053dd081911cfde22a4e) in how it handles quitting the game.