### PR TITLE
Restore keyboard controls

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -50,9 +50,10 @@ state bit 2 is edge triggered on the down to up transition
 ===============================================================================
 */
 
+kbutton_t in_mlook = {.state = 1}, in_klook;
 kbutton_t in_left, in_right, in_forward, in_back;
 kbutton_t in_lookup, in_lookdown, in_moveleft, in_moveright;
-kbutton_t in_speed, in_use, in_jump, in_attack;
+kbutton_t in_strafe, in_speed, in_use, in_jump, in_attack;
 kbutton_t in_up, in_down;
 
 int in_impulse;
@@ -116,6 +117,24 @@ void KeyUp (kbutton_t *b)
 	b->state |= 4;	// impulse up
 }
 
+void IN_KLookDown (void)
+{
+	KeyDown (&in_klook);
+}
+void IN_KLookUp (void)
+{
+	KeyUp (&in_klook);
+}
+void IN_MLookDown (void)
+{
+	KeyDown (&in_mlook);
+}
+void IN_MLookUp (void)
+{
+	KeyUp (&in_mlook);
+	if (!(in_mlook.state & 1) && lookspring.value)
+		V_StartPitchDrift ();
+}
 void IN_UpDown (void)
 {
 	KeyDown (&in_up);
@@ -204,6 +223,14 @@ void IN_SpeedDown (void)
 void IN_SpeedUp (void)
 {
 	KeyUp (&in_speed);
+}
+void IN_StrafeDown (void)
+{
+	KeyDown (&in_strafe);
+}
+void IN_StrafeUp (void)
+{
+	KeyUp (&in_strafe);
 }
 
 void IN_AttackDown (void)
@@ -339,11 +366,27 @@ void CL_AdjustAngles (void)
 	else
 		speed = host_frametime;
 
+	if (!(in_strafe.state & 1))
+	{
+		cl.viewangles[YAW] -= speed * cl_yawspeed.value * CL_KeyState (&in_right);
+		cl.viewangles[YAW] += speed * cl_yawspeed.value * CL_KeyState (&in_left);
+		cl.viewangles[YAW] = anglemod (cl.viewangles[YAW]);
+	}
+	if (in_klook.state & 1)
+	{
+		V_StopPitchDrift ();
+		cl.viewangles[PITCH] -= speed * cl_pitchspeed.value * CL_KeyState (&in_forward);
+		cl.viewangles[PITCH] += speed * cl_pitchspeed.value * CL_KeyState (&in_back);
+	}
+
 	up = CL_KeyState (&in_lookup);
 	down = CL_KeyState (&in_lookdown);
 
 	cl.viewangles[PITCH] -= speed * cl_pitchspeed.value * up;
 	cl.viewangles[PITCH] += speed * cl_pitchspeed.value * down;
+
+	if (up || down)
+		V_StopPitchDrift ();
 
 	// johnfitz -- variable pitch clamping
 	if (cl.viewangles[PITCH] > cl_maxpitch.value)
@@ -374,14 +417,23 @@ void CL_BaseMove (usercmd_t *cmd)
 	if (cls.signon != SIGNONS)
 		return;
 
+	if (in_strafe.state & 1)
+	{
+		cmd->sidemove += cl_sidespeed.value * CL_KeyState (&in_right);
+		cmd->sidemove -= cl_sidespeed.value * CL_KeyState (&in_left);
+	}
+
 	cmd->sidemove += cl_sidespeed.value * CL_KeyState (&in_moveright);
 	cmd->sidemove -= cl_sidespeed.value * CL_KeyState (&in_moveleft);
 
 	cmd->upmove += cl_upspeed.value * CL_KeyState (&in_up);
 	cmd->upmove -= cl_upspeed.value * CL_KeyState (&in_down);
 
-	cmd->forwardmove += cl_forwardspeed.value * CL_KeyState (&in_forward);
-	cmd->forwardmove -= cl_backspeed.value * CL_KeyState (&in_back);
+	if (!(in_klook.state & 1))
+	{
+		cmd->forwardmove += cl_forwardspeed.value * CL_KeyState (&in_forward);
+		cmd->forwardmove -= cl_backspeed.value * CL_KeyState (&in_back);
+	}
 
 	//
 	// adjust for speed key
@@ -530,6 +582,8 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("-lookup", IN_LookupUp);
 	Cmd_AddCommand ("+lookdown", IN_LookdownDown);
 	Cmd_AddCommand ("-lookdown", IN_LookdownUp);
+	Cmd_AddCommand ("+strafe", IN_StrafeDown);
+	Cmd_AddCommand ("-strafe", IN_StrafeUp);
 	Cmd_AddCommand ("+moveleft", IN_MoveleftDown);
 	Cmd_AddCommand ("-moveleft", IN_MoveleftUp);
 	Cmd_AddCommand ("+moveright", IN_MoverightDown);
@@ -543,4 +597,8 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("+jump", IN_JumpDown);
 	Cmd_AddCommand ("-jump", IN_JumpUp);
 	Cmd_AddCommand ("impulse", IN_Impulse);
+	Cmd_AddCommand ("+klook", IN_KLookDown);
+	Cmd_AddCommand ("-klook", IN_KLookUp);
+	Cmd_AddCommand ("+mlook", IN_MLookDown);
+	Cmd_AddCommand ("-mlook", IN_MLookUp);
 }

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -36,8 +36,8 @@ cvar_t cl_nolerp = {"cl_nolerp", "0", CVAR_NONE};
 
 cvar_t cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
-cvar_t lookspring = {"lookspring", "0", CVAR_ARCHIVE};
-cvar_t lookstrafe = {"lookstrafe", "0", CVAR_ARCHIVE};
+cvar_t lookspring = {"lookspring", "0", CVAR_NONE};
+cvar_t lookstrafe = {"lookstrafe", "0", CVAR_NONE};
 cvar_t sensitivity = {"sensitivity", "3", CVAR_ARCHIVE};
 
 cvar_t m_pitch = {"m_pitch", "0.022", CVAR_ARCHIVE};

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -877,6 +877,9 @@ static void CL_ParseServerInfo (void)
 	//
 	CL_ClearState ();
 
+	if (sv.loadgame)
+		V_StopPitchDrift ();
+
 	// parse protocol version number
 	for (;;)
 	{

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -310,6 +310,8 @@ extern cvar_t cl_nolerp;
 extern cvar_t cfg_unbindall;
 
 extern cvar_t cl_pitchdriftspeed;
+extern cvar_t lookspring;
+extern cvar_t lookstrafe;
 extern cvar_t sensitivity;
 extern cvar_t crosshair;
 
@@ -367,6 +369,8 @@ typedef struct
 	int state;	 // low bit is down state
 } kbutton_t;
 
+extern kbutton_t in_mlook, in_klook;
+extern kbutton_t in_strafe;
 extern kbutton_t in_speed;
 
 void	 CL_InitInput (void);
@@ -410,6 +414,9 @@ void CL_NewTranslation (int slot);
 //
 // view
 //
+void V_StartPitchDrift (void);
+void V_StopPitchDrift (void);
+
 void V_ParseDamage (void);
 void V_SetContentsColor (int contents);
 

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -368,6 +368,7 @@ void Host_WriteConfiguration (void)
 
 		// johnfitz -- extra commands to preserve state
 		fprintf (f, "vid_restart\n");
+		fprintf (f, "+mlook\n"); // always enable mouse look on config, can be overriden by -mlook in autoexec.cfg
 		// johnfitz
 
 		fclose (f);

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -556,6 +556,9 @@ void IN_JoyMove (usercmd_t *cmd)
 	cl.viewangles[YAW] -= lookEased.x * joy_sensitivity_yaw.value * host_frametime;
 	cl.viewangles[PITCH] += lookEased.y * joy_sensitivity_pitch.value * (joy_invert.value ? -1.0 : 1.0) * host_frametime;
 
+	if (lookEased.x != 0 || lookEased.y != 0)
+		V_StopPitchDrift ();
+
 	/* johnfitz -- variable pitch clamping */
 	if (cl.viewangles[PITCH] > cl_maxpitch.value)
 		cl.viewangles[PITCH] = cl_maxpitch.value;
@@ -581,13 +584,33 @@ void IN_MouseMove (usercmd_t *cmd)
 	if (cl.paused || key_dest != key_game)
 		return;
 
-	cl.viewangles[YAW] -= m_yaw.value * dmx;
-	cl.viewangles[PITCH] += m_pitch.value * dmy;
-	/* johnfitz -- variable pitch clamping */
-	if (cl.viewangles[PITCH] > cl_maxpitch.value)
-		cl.viewangles[PITCH] = cl_maxpitch.value;
-	if (cl.viewangles[PITCH] < cl_minpitch.value)
-		cl.viewangles[PITCH] = cl_minpitch.value;
+	if ((in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1)))
+		cmd->sidemove_accumulator += m_side.value * dmx;
+	else
+		cl.viewangles[YAW] -= m_yaw.value * dmx;
+
+	if (in_mlook.state & 1)
+	{
+		if (dmx || dmy)
+			V_StopPitchDrift ();
+	}
+
+	if ((in_mlook.state & 1) && !(in_strafe.state & 1))
+	{
+		cl.viewangles[PITCH] += m_pitch.value * dmy;
+		/* johnfitz -- variable pitch clamping */
+		if (cl.viewangles[PITCH] > cl_maxpitch.value)
+			cl.viewangles[PITCH] = cl_maxpitch.value;
+		if (cl.viewangles[PITCH] < cl_minpitch.value)
+			cl.viewangles[PITCH] = cl_minpitch.value;
+	}
+	else
+	{
+		if ((in_strafe.state & 1) && noclip_anglehack)
+			cmd->upmove_accumulator -= m_forward.value * dmy;
+		else
+			cmd->forwardmove_accumulator -= m_forward.value * dmy;
+	}
 }
 
 void IN_Move (usercmd_t *cmd)

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -48,6 +48,8 @@ cvar_t v_kickroll = {"v_kickroll", "0.6", CVAR_NONE};
 cvar_t v_kickpitch = {"v_kickpitch", "0.6", CVAR_NONE};
 cvar_t v_gunkick = {"v_gunkick", "1", CVAR_ARCHIVE}; // johnfitz
 
+cvar_t v_autopitch = {"v_autopitch", "0", CVAR_ARCHIVE};
+
 cvar_t v_iyaw_cycle = {"v_iyaw_cycle", "2", CVAR_NONE};
 cvar_t v_iroll_cycle = {"v_iroll_cycle", "0.5", CVAR_NONE};
 cvar_t v_ipitch_cycle = {"v_ipitch_cycle", "1", CVAR_NONE};
@@ -208,7 +210,10 @@ void V_DriftPitch (void)
 		return;
 	}
 
-	delta = cl.statsf[STAT_IDEALPITCH] - cl.viewangles[PITCH];
+	if (v_autopitch.value)
+		delta = cl.statsf[STAT_IDEALPITCH] - cl.viewangles[PITCH];
+	else
+		delta = -cl.viewangles[PITCH];
 
 	if (!delta)
 	{
@@ -946,6 +951,8 @@ void V_Init (void)
 	Cvar_RegisterVariable (&v_kickroll);
 	Cvar_RegisterVariable (&v_kickpitch);
 	Cvar_RegisterVariable (&v_gunkick); // johnfitz
+
+	Cvar_RegisterVariable (&v_autopitch);
 
 	Cvar_RegisterVariable (&r_viewmodel_quake); // MarkV
 }

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -139,6 +139,108 @@ float V_CalcBob (void)
 	return bob;
 }
 
+//=============================================================================
+
+cvar_t v_centermove = {"v_centermove", "0.15", CVAR_NONE};
+cvar_t v_centerspeed = {"v_centerspeed", "500", CVAR_NONE};
+
+void V_StartPitchDrift (void)
+{
+#if 1
+	if (cl.laststop == cl.time)
+	{
+		return; // something else is keeping it from drifting
+	}
+#endif
+	if (cl.nodrift || !cl.pitchvel)
+	{
+		cl.pitchvel = v_centerspeed.value;
+		cl.nodrift = false;
+		cl.driftmove = 0;
+	}
+}
+
+void V_StopPitchDrift (void)
+{
+	cl.laststop = cl.time;
+	cl.nodrift = true;
+	cl.pitchvel = 0;
+}
+
+/*
+===============
+V_DriftPitch
+
+Moves the client pitch angle towards cl.idealpitch sent by the server.
+
+If the user is adjusting pitch manually, either with lookup/lookdown,
+mlook and mouse, or klook and keyboard, pitch drifting is constantly stopped.
+
+Drifting is enabled when the center view key is hit, mlook is released and
+lookspring is non 0, or when
+===============
+*/
+void V_DriftPitch (void)
+{
+	float delta, move;
+
+	if (noclip_anglehack || !cl.onground || cls.demoplayback || CL_AngleLocked ())
+	// FIXME: noclip_anglehack is set on the server, so in a nonlocal game this won't work.
+	{
+		cl.driftmove = 0;
+		cl.pitchvel = 0;
+		return;
+	}
+
+	// don't count small mouse motion
+	if (cl.nodrift)
+	{
+		if (fabs (cl.movecmds[(cl.movemessages - 1) & MOVECMDS_MASK].forwardmove) < cl_forwardspeed.value)
+			cl.driftmove = 0;
+		else
+			cl.driftmove += host_frametime;
+
+		if (cl.driftmove > v_centermove.value)
+		{
+			if (lookspring.value)
+				V_StartPitchDrift ();
+		}
+		return;
+	}
+
+	delta = cl.statsf[STAT_IDEALPITCH] - cl.viewangles[PITCH];
+
+	if (!delta)
+	{
+		cl.pitchvel = 0;
+		return;
+	}
+
+	move = host_frametime * cl.pitchvel;
+	cl.pitchvel += host_frametime * v_centerspeed.value;
+
+	// Con_Printf ("move: %f (%f)\n", move, host_frametime);
+
+	if (delta > 0)
+	{
+		if (move > delta)
+		{
+			cl.pitchvel = 0;
+			move = delta;
+		}
+		cl.viewangles[PITCH] += move;
+	}
+	else if (delta < 0)
+	{
+		if (move > -delta)
+		{
+			cl.pitchvel = 0;
+			move = -delta;
+		}
+		cl.viewangles[PITCH] -= move;
+	}
+}
+
 /*
 ==============================================================================
 
@@ -610,6 +712,8 @@ void V_CalcRefdef (void)
 	static vec3_t punch = {0, 0, 0}; // johnfitz -- v_gunkick
 	float		  delta;			 // johnfitz -- v_gunkick
 
+	V_DriftPitch ();
+
 	// ent is the player model (visible when out of body)
 	ent = &cl.entities[cl.viewentity];
 	// view is the weapon model (only visible from inside body)
@@ -809,6 +913,10 @@ void V_Init (void)
 {
 	Cmd_AddCommand ("v_cshift", V_cshift_f);
 	Cmd_AddCommand ("bf", V_BonusFlash_f);
+	Cmd_AddCommand ("centerview", V_StartPitchDrift);
+
+	Cvar_RegisterVariable (&v_centermove);
+	Cvar_RegisterVariable (&v_centerspeed);
 
 	Cvar_RegisterVariable (&v_iyaw_cycle);
 	Cvar_RegisterVariable (&v_iroll_cycle);


### PR DESCRIPTION
The options stay removed from the menu and are not written to the config file (except mouse look, which is always written as if it was enabled, for better compatibility).