### PR TITLE
r_lerpturn cvar for disabling rotation lerping on entities

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -64,6 +64,7 @@ entity_t **cl_visedicts;
 entity_t **cl_visedicts_alpha;
 
 extern cvar_t r_lerpmodels, r_lerpmove; // johnfitz
+extern cvar_t r_lerpturn;				// Danni
 extern float  host_netinterval;			// Spike
 
 qboolean needs_relink;
@@ -466,7 +467,7 @@ float CL_LerpPoint (void)
 
 static qboolean CL_LerpEntity (entity_t *ent, vec3_t org, vec3_t ang, float frac)
 {
-	float	 f, d;
+	float	 f, d, a;
 	int		 j;
 	vec3_t	 delta;
 	qboolean teleported = false;
@@ -490,9 +491,17 @@ static qboolean CL_LerpEntity (entity_t *ent, vec3_t org, vec3_t ang, float frac
 			}
 		}
 
+		a = f;
+
 		// johnfitz -- don't cl_lerp entities that will be r_lerped
 		if (r_lerpmove.value && (ent->lerpflags & LERP_MOVESTEP))
+		{
 			f = 1;
+
+			// same but for angles
+			if (r_lerpturn.value)
+				a = 1;
+		}
 		// johnfitz
 
 		// interpolate the origin and angles
@@ -505,7 +514,7 @@ static qboolean CL_LerpEntity (entity_t *ent, vec3_t org, vec3_t ang, float frac
 				d -= 360;
 			else if (d < -180)
 				d += 360;
-			ang[j] = ent->msg_angles[1][j] + f * d;
+			ang[j] = ent->msg_angles[1][j] + a * d;
 		}
 	}
 	return teleported;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -88,6 +88,7 @@ cvar_t r_showbboxes = {"r_showbboxes", "0", CVAR_NONE};
 cvar_t r_showbboxes_filter = {"r_showbboxes_filter", "", CVAR_NONE};
 cvar_t r_lerpmodels = {"r_lerpmodels", "1", CVAR_ARCHIVE};
 cvar_t r_lerpmove = {"r_lerpmove", "1", CVAR_ARCHIVE};
+cvar_t r_lerpturn = {"r_lerpturn", "1", CVAR_ARCHIVE};
 cvar_t r_nolerp_list = {
 	"r_nolerp_list",
 	"progs/flame.mdl,progs/flame2.mdl,progs/braztall.mdl,progs/brazshrt.mdl,progs/longtrch.mdl,progs/flame_pyre.mdl,progs/v_saw.mdl,progs/"

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -47,6 +47,7 @@ extern cvar_t r_showbboxes;
 extern cvar_t r_showbboxes_filter;
 extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
+extern cvar_t r_lerpturn;
 extern cvar_t r_nolerp_list;
 // johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -3608,6 +3609,7 @@ void R_Init (void)
 	Cvar_SetCallback (&gl_fullbrights, GL_Fullbrights_f);
 	Cvar_RegisterVariable (&r_lerpmodels);
 	Cvar_RegisterVariable (&r_lerpmove);
+	Cvar_RegisterVariable (&r_lerpturn);
 	Cvar_RegisterVariable (&r_nolerp_list);
 	Cvar_SetCallback (&r_nolerp_list, R_Model_ExtraFlags_List_f);
 	// johnfitz

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -116,6 +116,7 @@ extern cvar_t r_particles;
 extern cvar_t r_md5models;
 extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
+extern cvar_t r_lerpturn;
 extern cvar_t vid_filter;
 extern cvar_t vid_palettize;
 extern cvar_t vid_anisotropic;
@@ -1803,6 +1804,7 @@ static void M_GraphicsOptions_AdjustSliders (int dir, qboolean mouse)
 	case GRAPHICS_OPT_MODEL_INTERPOLATION:
 		Cvar_SetValueQuick (&r_lerpmodels, (float)(((int)r_lerpmodels.value + 2 + dir) % 2));
 		Cvar_SetValueQuick (&r_lerpmove, r_lerpmodels.value);
+		Cvar_SetValueQuick (&r_lerpturn, r_lerpmodels.value);
 		break;
 	case GRAPHICS_OPT_PARTICLES:
 		M_GraphicsOptions_ChooseNextParticles (dir);


### PR DESCRIPTION
A nice feature in modern Quake source ports is movement interpolation. This makes it much easier to track enemy movement, especially faster monsters such as Fiends. But one thing that's always bothered me is that it made them turn like Roombas!

So I decided to try turning off that part of the lerping so that only positional lerping is done. I quite like the result, as rotation is now done in lockstep with the animation, which looks much more natural, but you can still make out the entity's general trajectory:
https://user-images.githubusercontent.com/34800072/227813418-65f6dcbb-a1fd-4e34-8b61-8dbbc667b2ee.mp4

The new cvar, `r_lerpturn`, defaults to 1 so shouldn't affect existing configs. The setting has no effect when `r_lerpmove` is 0.

These changes have not been tested with attached entities. Do let me know how I can test this with `CL_LerpEntity`, and/or just straight up tell me whether this new lerping option breaks anything.