### PR TITLE
CI: build MacOS in release and debug mode

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -12,14 +12,16 @@ jobs:
     runs-on: macos-11
     strategy:
       fail-fast: false
+      matrix:
+        configuration: [release, debug]
     steps:
     - uses: actions/checkout@v3
     - name: Install Dependencies
       run: brew install molten-vk vulkan-headers glslang spirv-tools sdl2 libvorbis flac opus opusfile flac mad meson
     - name: Build vkQuake
-      run: meson build && ninja -C build
+      run: meson build --buildtype=${{ matrix.configuration }} && ninja -C build
     - name: Upload vkQuake
       uses: actions/upload-artifact@v3
       with:
-        name: vkQuake archive
+        name: vkQuake archive (${{ matrix.configuration }})
         path: build/vkquake


### PR DESCRIPTION
CI currently only builds a release build for MacOS. There's been several compilation errors specifically in MacOS debug builds that weren't caught by CI (https://github.com/Novum/vkQuake/issues/638 and https://github.com/Novum/vkQuake/issues/681), so this changes CI to catch these.

(This PR is failing CI because of https://github.com/Novum/vkQuake/issues/681.)