### PR TITLE
build x64 binaries first, same order as the win installers

### DIFF
--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows (mingw32),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686, makefile: Makefile.w32 }
         - { name: Windows (mingw64),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64, makefile: Makefile.w64 }
+        - { name: Windows (mingw32),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686, makefile: Makefile.w32 }
 
     steps:
     - name: Set up MSYS2


### PR DESCRIPTION
people do not read,  see 
https://www.slipseer.com/index.php?threads/the-immortal-lock.526/post-3595