### PR TITLE
Switch building AppImages to Ubuntu 22.04

### DIFF
--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y apt-transport-https ca-certificates wget gnupg apt-utils \
- && wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - \
- && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.275-focal.list https://packages.lunarg.com/vulkan/1.3.275/lunarg-vulkan-1.3.275-focal.list \
+ && wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | tee /etc/apt/trusted.gpg.d/lunarg.asc \
+ && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.275-jammy.list https://packages.lunarg.com/vulkan/1.3.275/lunarg-vulkan-1.3.275-jammy.list \
  && apt-get update \
  && apt-get install -y \
 	build-essential \

--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update \
 	libudev-dev \
 	libusb-dev \
 	libvorbis-dev \
-	libvorbis-dev \
 	libvulkan-dev \
 	libx11-xcb-dev \
 	libxcursor-dev \


### PR DESCRIPTION
In case  you want to switch the docker image from 20.04 to 22.04  at some point.
This is not needed right now.
