### PR TITLE
SV_Physics() : Performance boost for SV_PushMove() when there is a lot of pushers and pushed entities.

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1136,6 +1136,7 @@ void SV_Init (void)
 	extern cvar_t sv_gameplayfix_spawnbeforethinks;
 	extern cvar_t sv_gameplayfix_bouncedownslopes;
 	extern cvar_t sv_gameplayfix_elevators;
+	extern cvar_t sv_fastpushmove;
 	extern cvar_t sv_friction;
 	extern cvar_t sv_edgefriction;
 	extern cvar_t sv_stopspeed;
@@ -1162,6 +1163,7 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_gameplayfix_spawnbeforethinks);
 	Cvar_RegisterVariable (&sv_gameplayfix_bouncedownslopes);
 	Cvar_RegisterVariable (&sv_gameplayfix_elevators);
+	Cvar_RegisterVariable (&sv_fastpushmove);
 	Cvar_RegisterVariable (&pr_checkextension);
 	Cvar_RegisterVariable (&sv_altnoclip); // johnfitz
 	Cvar_RegisterVariable (&sv_netsort);


### PR DESCRIPTION
On my machine :
- Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz + Nvidia GTX 1050Ti 4GB = a middle-range gaming laptop of...2017.

This significantly boost the perf in case there is a ton of edicts and ton of MOVETYPE_PUSH pushers

Found with [The Immortal Lock ](https://www.slipseer.com/index.php?resources/the-immortal-lock.371/)
at this place in particular for comparison :  [s17_immortal_lock.zip](https://github.com/user-attachments/files/16909386/s17_immortal_lock.zip)

The change consist in pre-computing the list of 'pushable' entities once per `SV_Physics()` on which `SV_PushMove()` will iterate.

By comparison, the original code iterate all `qcvm->num_edicts` at each `SV_PushMove()`.

Turns out this simple change has a great impact on the fps in my case, just by shortenning the iteration or maybe by prefetching entities, because otherwise `SV_PushMove()` completly bottlenecks the rendering part, especially when `host_maxfps 0`.

Main settings :
- `vsync off`
- Antialiasing : Multisample a.k.a Edge-only 4x
- Anisotropic 16x
- Resolution : 2560 x 1440
- `r_novis 0` : This is the default, but it __does__ have a very positive impact here. I never played a level before this one where `r_novis 0/1` made the slightest difference. Not this time, though.
- Display : 2560 x 1440 @60Hz

This shows the `Min-Max` FPS you can get depending where you look in the scene: 

|  \  | vkQuake `sv_fastpushmove 0` (default)| vkQuake `sv_fastpushmove 1`|Ironwail `cb1ebef`| 
| --- | --- | --- | --- |
| `host_maxfps 58` | 52-58| 58-58 | 58-58 |
|`host_maxfps 0` | 37-94 | 63-155 | 100-110 |

Another example by @j4reporting:

Machine: Intel nuc11phki7 ( Intel i7-1165g7 @2.80Ghz + Nvidia 2600 RTX mobile )
Resolution : 2560 x 1440
Display:  2560x1440 @144Hz
Main setting : `host_maxfps 0`

|  vkQuake `sv_fastpushmove 0` (default)| vkQuake `sv_fastpushmove 1`|Ironwail (recent master) | 
 | --- | --- | --- |
 | 70-400 | 100-650 | 670-800 |

Now, this change is not a benign one... It assumes the list of MOVETYPE_PUSH pushers and pushable entities is frozen within a single frame, that is if `PR_ExecuteProgram` has side-effects and changes the `movetype` or even allocates / free eddicts, it is going to be taken into account the next frame only.

I'm oppening this to share ideas, opinions, and (God forbid) bug reports.

This optimization, if valid, could be also applied for @sezero QS and @andrei-drexler Ironwail.
  