### PR TITLE
Fix implicit int-float conversion error on clang

### DIFF
--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -1755,7 +1755,7 @@ void PR_spawnfunc_misc_model (edict_t *self)
 		self->v.model = PR_SetEngineString ("*null");
 
 	if (self->v.angles[1] < 0) // mimic AD. shame there's no avelocity clientside.
-		self->v.angles[1] = (rand () * (360.0f / RAND_MAX));
+		self->v.angles[1] = (rand () * (360.0f / (float)RAND_MAX));
 
 	// make sure the model is precached, to avoid errors.
 	G_INT (OFS_PARM0) = self->v.model;


### PR DESCRIPTION
Clang has the [`-Wimplicit-int-float-conversion`](https://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-int-float-conversion) flag, which makes the build fail when compiling with Clang. Changing the single line of code to do an explicit conversion fixes this specific build issue that Clang users might experience while trying to compile vkQuake out in the wild (I was one of them).

These are my logs with the build fail when I tried to build vkQuake prior to the fix:
<details>
  <summary>Build Logs</summary>

  ```
  ➜    vkQuake git:(master) meson build
  The Meson build system
  Version: 0.61.2
  Source dir: /home/willian/dev/software/vkQuake
  Build dir: /home/willian/dev/software/vkQuake/build
  Build type: native build
  Project name: vkquake
  Project version: undefined
  C compiler for the host machine: cc (clang 18.1.8 "Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)")
  C linker for the host machine: cc ld.bfd 2.38
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Program glslangValidator found: YES (/usr/bin/glslangValidator)
  Program spirv-opt found: YES (/usr/bin/spirv-opt)
  Program spirv-remap found: YES (/usr/bin/spirv-remap)
  Library m found: YES
  Library dl found: YES
  Run-time dependency threads found: YES
  Found pkg-config: /usr/bin/pkg-config (0.29.2)
  Run-time dependency sdl2 found: YES 2.31.0
  Run-time dependency vulkan found: YES 1.3.204
  Run-time dependency mad found: YES 0.15.0b
  Run-time dependency flac found: YES 1.3.3
  Run-time dependency ogg found: YES 1.3.5
  Run-time dependency vorbisfile found: YES 1.3.7
  Run-time dependency vorbis found: YES 1.3.7
  Run-time dependency opus found: YES 1.3.1
  Run-time dependency opusfile found: YES 0.9+20170913
  Build targets in project: 33
  
  Found ninja-1.10.1 at /usr/bin/ninja
  ➜    vkQuake git:(master) ninja -C build -j4
  ninja: Entering directory `build'
  [3/149] Generating Shaders_alias_alphatest_frag with a custom command
  ../Shaders/alias_alphatest.frag
  [4/149] Generating Shaders_alias_frag with a custom command
  ../Shaders/alias.frag
  [5/149] Generating Shaders_alias_vert with a custom command
  ../Shaders/alias.vert
  [6/149] Generating Shaders_basic_frag with a custom command
  ../Shaders/basic.frag
  [7/149] Generating Shaders_md5_vert with a custom command
  ../Shaders/md5.vert
  [8/149] Generating Shaders_basic_vert with a custom command
  ../Shaders/basic.vert
  [9/149] Generating Shaders_basic_alphatest_frag with a custom command
  ../Shaders/basic_alphatest.frag
  [10/149] Generating Shaders_basic_notex_frag with a custom command
  ../Shaders/basic_notex.frag
  [11/149] Generating Shaders_cs_tex_warp_comp with a custom command
  ../Shaders/cs_tex_warp.comp
  [12/149] Generating Shaders_indirect_comp with a custom command
  ../Shaders/indirect.comp
  [13/149] Generating Shaders_indirect_clear_comp with a custom command
  ../Shaders/indirect_clear.comp
  [14/149] Generating Shaders_postprocess_frag with a custom command
  ../Shaders/postprocess.frag
  [15/149] Generating Shaders_postprocess_vert with a custom command
  ../Shaders/postprocess.vert
  [16/149] Generating Shaders_screen_eff...10bit_scale_comp with a custom command
  ../Shaders/screen_effects_10bit_scale.comp
  [17/149] Generating Shaders_screen_effects_10bit_comp with a custom command
  ../Shaders/screen_effects_10bit.comp
  [18/149] Generating Shaders_screen_effects_8bit_scale_comp with a custom command
  ../Shaders/screen_effects_8bit_scale.comp
  [19/149] Generating Shaders_screen_effects_8bit_comp with a custom command
  ../Shaders/screen_effects_8bit.comp
  [20/149] Generating Shaders_screen_eff..._scale_sops_comp with a custom command
  ../Shaders/screen_effects_10bit_scale_sops.comp
  [21/149] Generating Shaders_showtris_frag with a custom command
  ../Shaders/showtris.frag
  [22/149] Generating Shaders_showtris_vert with a custom command
  ../Shaders/showtris.vert
  [23/149] Generating Shaders_screen_eff..._scale_sops_comp with a custom command
  ../Shaders/screen_effects_8bit_scale_sops.comp
  [25/149] Generating Shaders_sky_box_frag with a custom command
  ../Shaders/sky_box.frag
  [26/149] Generating Shaders_sky_cube_frag with a custom command
  ../Shaders/sky_cube.frag
  [27/149] Generating Shaders_sky_layer_frag with a custom command
  ../Shaders/sky_layer.frag
  [28/149] Generating Shaders_sky_layer_vert with a custom command
  ../Shaders/sky_layer.vert
  [29/149] Generating Shaders_sky_cube_vert with a custom command
  ../Shaders/sky_cube.vert
  [30/149] Generating Shaders_update_lightmap_comp with a custom command
  ../Shaders/update_lightmap.comp
  [31/149] Generating Shaders_update_lightmap_rt_comp with a custom command
  ../Shaders/update_lightmap_rt.comp
  [34/149] Generating Shaders_world_vert with a custom command
  ../Shaders/world.vert
  [35/149] Generating Shaders_world_frag with a custom command
  ../Shaders/world.frag
  [41/149] Generating Shaders_ray_debug_comp with a custom command
  ../Shaders/ray_debug.comp
  [111/149] Compiling C object vkquake.p/Quake_pr_cmds.c.o
  FAILED: vkquake.p/Quake_pr_cmds.c.o
  cc -Ivkquake.p -I. -I.. -I../Quake/mimalloc -I/usr/local/include -I/usr/local/include/SDL2 -I/usr/include/opus -fcolor-diagnostics -include-pch vkquake.p/quakedef.h.pch -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 -O3 -D_REENTRANT -pthread -Wall -Wno-trigraphs -Werror -std=gnu11 -DUSE_CODEC_WAVE -DUSE_CODEC_MP3 -DUSE_CODEC_FLAC -DUSE_CODEC_VORBIS -DUSE_CODEC_OPUS -MD -MQ vkquake.p/Quake_pr_cmds.c.o -MF vkquake.p/Quake_pr_cmds.c.o.d -o vkquake.p/Quake_pr_cmds.c.o -c ../Quake/pr_cmds.c
  ../Quake/pr_cmds.c:1758:44: error: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Werror,-Wimplicit-const-int-float-conversion]
   1758 |                 self->v.angles[1] = (rand () * (360.0f / RAND_MAX));
        |                                                        ~ ^~~~~~~~
  /usr/include/stdlib.h:87:18: note: expanded from macro 'RAND_MAX'
     87 | #define RAND_MAX        2147483647
        |                         ^~~~~~~~~~
  1 error generated.
  [114/149] Compiling C object vkquake.p/Quake_image.c.o
  ninja: build stopped: subcommand failed.
  ```
</details>