### PR TITLE
Fix #734: Restore rebuild freelist to preserve consitency after loading, ED_Alloc: properly initialize new edicts

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1212,6 +1212,10 @@ static void Host_Savegame_f (void)
 
 	Con_Printf ("done.\n");
 
+	// Take the occasion to rebuild the free list
+	// since saving is a long operation anyway
+	ED_RebuildFreeList (false);
+
 	PR_SwitchQCVM (NULL);
 	SaveList_Rebuild ();
 
@@ -1627,8 +1631,12 @@ static void Host_Loadgame_f (void)
 
 		Send_Spawn_Info (svs.clients, true);
 	}
+	else if (entnum < qcvm->num_edicts)
+		Con_Warning ("Save game had less entities than map (%d < %d)\n", entnum, qcvm->num_edicts); // should be Host_Error, but try to recover
 
 	qcvm->num_edicts = entnum;
+
+	ED_RebuildFreeList (true);
 
 	Mem_Free (start);
 	start = NULL;

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -110,6 +110,7 @@ void PR_Profile_f (void);
 edict_t *ED_Alloc (void);
 void	 ED_Free (edict_t *ed);
 void	 ED_RemoveFromFreeList (edict_t *ed);
+void	 ED_RebuildFreeList (bool force_free_reuse);
 
 void		ED_Print (edict_t *ed);
 void		ED_Write (FILE *f, edict_t *ed);


### PR DESCRIPTION
ED_Alloc : for 'new' edicts, assure they are properly reset just like < 1.30.0 did

see #734