### PR TITLE
Fix the README sections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,26 @@ Prerequisites:
 Open the Visual Studio solution, `Windows\VisualStudio\vkquake.sln`, select the desired configuration and platform, then
 build the solution.
 
+### MinGW
+
+Setup your [MinGW-w64](https://sourceforge.net/projects/mingw-w64/) environment, e.g. using [w64devkit](https://github.com/skeeto/w64devkit) or [MSYS2](https://www.msys2.org/).
+
+Build 32 bit (x86) vkQuake:
+
+~~~
+cd vkQuake/Quake
+make -f Makefile.w32
+~~~
+
+Build 64 bit (x64) vkQuake:
+
+~~~
+cd vkQuake/Quake
+make -f Makefile.w64
+~~~
+
+If you are on Linux and want to cross-compile for Windows, see the `build_cross_win??.sh` scripts.
+
 ## Linux
 
 Make sure that both your GPU and your GPU driver support [Vulkan](https://en.wikipedia.org/wiki/Vulkan#Support_across_vendors).
@@ -132,26 +152,6 @@ meson build && ninja -C build
 
 > **Note**\
 > The Meson version needs to be 0.47.0 or newer.
-
-### MinGW
-
-Setup your [MinGW-w64](https://sourceforge.net/projects/mingw-w64/) environment, e.g. using [w64devkit](https://github.com/skeeto/w64devkit) or [MSYS2](https://www.msys2.org/).
-
-Build 32 bit (x86) vkQuake:
-
-~~~
-cd vkQuake/Quake
-make -f Makefile.w32
-~~~
-
-Build 64 bit (x64) vkQuake:
-
-~~~
-cd vkQuake/Quake
-make -f Makefile.w64
-~~~
-
-If you are on Linux and want to cross-compile for Windows, see the `build_cross_win??.sh` scripts.
 
 # Optional - Music / Soundtrack
 

--- a/readme.md
+++ b/readme.md
@@ -18,20 +18,20 @@ Improvements over QuakeSpasm include:
 * Support for custom mod HUDs (from QSS)
 * Support for scriptable particles (from QSS)
 
-# Installation
+## Installation
 
-## Windows
+### Windows
 It is recommended to use the installer on Windows. This sets up start menu entries for the original and remastered Quake versions. Save data and config files will be written to the user folder (`%APPDATA\vkQuake`) instead of the Quake data folder.
 
 Otherwise copy all files inside the `vkquake-<version>_win64` or `vkquake-<version>_win32` folder in the zip to the Quake base directory. Overwrite any existing files. Afterward to run the game just execute `vkQuake.exe`.
 
-## Linux
+### Linux
 Copy all files inside the `vkquake-<version>-linux64` folder in the tar archive to the Quake base directory. Overwrite any existing files. Run `vkquake.AppImage`.
 
 > **Note**\
 > Make sure all data files are lowercase, e.g. "id1", not "ID1" and "pak0.pak", not "PAK0.PAK". Some distributions of the game have upper case file names, e.g. from GOG.com.
 
-## OpenBSD
+### OpenBSD
 
 [OpenBSD](https://openbsd.org) includes vkQuake in the standard package repositories since version [6.6](https://www.openbsd.org/66.html).
 
@@ -41,18 +41,18 @@ If you're running `OpenBSD 6.6` or greater you can install the package with:
 $ pkg_add vkquake
 ```
 
-## Quake '2021 re-release'
+### Quake '2021 re-release'
 
 vkQuake has initial support for playing the 2021 re-release content. Follow installation instructions as above but copy the files into the rerelease folder.
 
-# Vulkan
+## Vulkan
 vkQuake shows basic usage of the API. For example it demonstrates render passes & sub passes, pipeline barriers & synchronization, compute shaders, push & specialization constants, CPU/GPU parallelism and memory pooling.
 
-# Building
+## Building
 > **Note**\
 > You will need at least Vulkan SDK version 1.2.162 or newer. When building for Linux this is not always the case for the SDK provided by the distribution. Install the latest LunarG SDK if necessary.
 
-## Windows
+### Windows
 
 Clone the vkQuake repo from `https://github.com/Novum/vkQuake.git`
 
@@ -62,14 +62,14 @@ Prerequisites:
 * A [Vulkan-capable GPU](https://en.wikipedia.org/wiki/Vulkan_(API)#Compatibility) with the appropriate drivers installed
 * Install the latest [Vulkan SDK](https://vulkan.lunarg.com/sdk/home). Log out and back in after installation to make sure environment variables are set.
 
-### Visual Studio
+#### Visual Studio
 
 * Install [Visual Studio Community](https://www.visualstudio.com/products/free-developer-offers-vs) with Visual C++ component.
 
 Open the Visual Studio solution, `Windows\VisualStudio\vkquake.sln`, select the desired configuration and platform, then
 build the solution.
 
-### MinGW
+#### MinGW
 
 Setup your [MinGW-w64](https://sourceforge.net/projects/mingw-w64/) environment, e.g. using [w64devkit](https://github.com/skeeto/w64devkit) or [MSYS2](https://www.msys2.org/).
 
@@ -89,7 +89,7 @@ make -f Makefile.w64
 
 If you are on Linux and want to cross-compile for Windows, see the `build_cross_win??.sh` scripts.
 
-## Linux
+### Linux
 
 Make sure that both your GPU and your GPU driver support [Vulkan](https://en.wikipedia.org/wiki/Vulkan#Support_across_vendors).
 
@@ -129,7 +129,7 @@ meson build && ninja -C build
 > **Note**\
 > vkQuake 0.97 and later requires at least **SDL2 2.0.6 with enabled Vulkan support**. The precompiled versions in some of the distribution repositories (e.g. Ubuntu) do not currently ship with Vulkan support. You will therefore need to compile it from source. Make sure you have libvulkan-dev installed before running configure.
 
-## MacOS
+### MacOS
 
 To compile vkQuake, first install the build dependencies with Homebrew:
 
@@ -153,7 +153,7 @@ meson build && ninja -C build
 > **Note**\
 > The Meson version needs to be 0.47.0 or newer.
 
-# Optional - Music / Soundtrack
+## Optional - Music / Soundtrack
 
 > **Note**\
 > This section only applies to older releases. For the 2021 re-release music will work out of the box.


### PR DESCRIPTION
I noticed that the MinGW section was in the MacOS section, which seemed odd. It was moved from the Windows section in f9df8516d3027da854186c74d36243f2d11cb8ad.

I see two options: move MinGW back to the Windows section, or raise its heading level so that MinGW is on the same level as the Linux and MacOS sections. I've chosen the first one.

Regarding the heading levels, see the commit message.
