### PR TITLE
Keep building linux AppImage with libmad, resolves issue #756

### DIFF
--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 	libaudiofile-dev \
 	libdbus-1-dev \
 	libibus-1.0-dev \
-	libmpg123-dev \
+	libmad0-dev \
 	libopenal-dev \
 	libpulse-dev \
 	libsndio-dev \

--- a/Packaging/AppImage/run-in-docker.sh
+++ b/Packaging/AppImage/run-in-docker.sh
@@ -8,7 +8,7 @@ cd /usr/src/vkQuake
 
 rm -rf build/appimage
 
-python3 /opt/meson/meson.py build/appimage -Dbuildtype=release -Db_lto=true
+python3 /opt/meson/meson.py build/appimage -Dbuildtype=release -Db_lto=true -Dmp3_lib=mad
 ninja -C build/appimage
 
 cd Packaging/AppImage


### PR DESCRIPTION
introduced  with commit 8b42de7  and  commit 7068875 
this breaks audio for newer linux systems If pulseaudio ( libpulse0 ) is used by the system. 

This can probably be reverted when we update the docker image to Ubuntu 22.04 at some point.
