### PR TITLE
include libpulse and friends in AppImage, alternative solution for  issue #756

### DIFF
--- a/Packaging/AppImage/run-in-docker.sh
+++ b/Packaging/AppImage/run-in-docker.sh
@@ -17,6 +17,7 @@ rm -rf vkquake*
 mkdir "$FOLDER"
 ./linuxdeploy-x86_64.AppImage \
 	-e ../../build/appimage/vkquake --appdir=AppDir --create-desktop-file \
+ 	-l ../../../../lib/x86_64-linux-gnu/libpulse.so.0 \
 	-i ../../Misc/vkQuake_256.png --icon-filename=vkquake --output appimage
 
 cp "vkquake-$VERSION-x86_64.AppImage" "$FOLDER/vkquake.AppImage"


### PR DESCRIPTION
I think going back to mad is the simpler solution, though. And it has less potential to break things again. 
List of  libs included in the AppImages created.

**libmad**:
```
$ ./vkquake.AppImage --appimage-mount 
/tmp/.mount_vkquakAKNcAI
$  ll /tmp/.mount_vkquakAKNcAI/usr/lib/
total 3572
-rw-r--r--. 1 root root  265720 Jan  4 11:36 libFLAC.so.8
-rw-r--r--. 1 root root  141168 Jan  4 11:36 libmad.so.0
-rw-r--r--. 1 root root   51784 Jan  4 11:36 libogg.so.0
-rw-r--r--. 1 root root   51936 Jan  4 11:36 libopusfile.so.0
-rw-r--r--. 1 root root  388352 Jan  4 11:36 libopus.so.0
-rwxr-xr-x. 1 root root 2036480 Jan  4 11:36 libSDL2-2.0.so.0
-rw-r--r--. 1 root root   43408 Jan  4 11:36 libvorbisfile.so.3
-rw-r--r--. 1 root root  188680 Jan  4 11:36 libvorbis.so.0
-rw-r--r--. 1 root root  492896 Jan  4 11:36 libvulkan.so.1
```

**libmpg123**:
```
$ ./vkquake.AppImage --appimage-mount
/tmp/.mount_vkquakZwD0L5
$ ll //tmp/.mount_vkquakZwD0L5/usr/lib/
total 8736
-rw-r--r--. 1 root root   85480 Jan  2 21:54 libapparmor.so.1
-rw-r--r--. 1 root root   26208 Jan  2 21:54 libasyncns.so.0
-rw-r--r--. 1 root root  102280 Jan  2 21:54 libbsd.so.0
-rw-r--r--. 1 root root  348624 Jan  2 21:54 libdbus-1.so.3
-rw-r--r--. 1 root root  265720 Jan  2 21:54 libFLAC.so.8
-rw-r--r--. 1 root root 1178576 Jan  2 21:54 libgcrypt.so.20
-rw-r--r--. 1 root root  134808 Jan  2 21:54 liblz4.so.1
-rw-r--r--. 1 root root  168128 Jan  2 21:54 liblzma.so.5
-rw-r--r--. 1 root root  327640 Jan  2 21:54 libmpg123.so.0
-rw-r--r--. 1 root root  112024 Jan  2 21:54 libnsl.so.1
-rw-r--r--. 1 root root   51784 Jan  2 21:54 libogg.so.0
-rw-r--r--. 1 root root   51936 Jan  2 21:54 libopusfile.so.0
-rw-r--r--. 1 root root  388352 Jan  2 21:54 libopus.so.0
-rw-r--r--. 1 root root  557120 Jan  2 21:54 libpulsecommon-13.99.so
-rw-r--r--. 1 root root  343240 Jan  2 21:54 libpulse.so.0
-rwxr-xr-x. 1 root root 2036480 Jan  2 21:54 libSDL2-2.0.so.0
-rw-r--r--. 1 root root  516200 Jan  2 21:54 libsndfile.so.1
-rw-r--r--. 1 root root  734920 Jan  2 21:54 libsystemd.so.0
-rw-r--r--. 1 root root  697688 Jan  2 21:54 libvorbisenc.so.2
-rw-r--r--. 1 root root   43408 Jan  2 21:54 libvorbisfile.so.3
-rw-r--r--. 1 root root  188680 Jan  2 21:54 libvorbis.so.0
-rw-r--r--. 1 root root  492896 Jan  2 21:54 libvulkan.so.1
-rw-r--r--. 1 root root   47456 Jan  2 21:54 libwrap.so.0
-rw-r--r--. 1 root root   22472 Jan  2 21:54 libXau.so.6
-rw-r--r--. 1 root root   30616 Jan  2 21:54 libXdmcp.so.6
```

