### PR TITLE
Import DP_SV_NODRAWTOCLIENT and DP_SV_DRAWONLYTOCLIENT from QSS

### DIFF
--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -279,8 +279,8 @@ struct pr_extfields_s
 	/*ssqc-only*/                                                                   \
 	QCEXTFIELD (items2, "//.float")									 /*float*/      \
 	QCEXTFIELD (movement, ".vector")								 /*vector*/     \
-	QCEXTFIELD (viewmodelforclient, ".entity")						 /*entity*/     \
-	QCEXTFIELD (exteriormodeltoclient, ".entity")					 /*entity*/     \
+	QCEXTFIELD (nodrawtoclient, ".entity")						 /*entity*/     \
+	QCEXTFIELD (drawonlytoclient, ".entity")					 /*entity*/     \
 	QCEXTFIELD (traileffectnum, ".float")							 /*float*/      \
 	QCEXTFIELD (emiteffectnum, ".float")							 /*float*/      \
 	QCEXTFIELD (button3, ".float")									 /*float*/      \

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1955,12 +1955,12 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, size_t overflow
 	{
 		if (ent != clent) // clent already added before the loop
 		{
-			// hide from the specified client
+			// hide if the current client is specified
 			val = GetEdictFieldValue(ent, qcvm->extfields.nodrawtoclient);
 			if (val && val->edict == EDICT_TO_PROG(client))
 				continue;
 
-			// hide from an unspecified client
+			// hide if the current client is not specified
 			val = GetEdictFieldValue(ent, qcvm->extfields.drawonlytoclient);
 			if (val && val->edict && val->edict != EDICT_TO_PROG(client))
 				continue;


### PR DESCRIPTION
The [attached archive](https://github.com/user-attachments/files/19351367/test_qcext.zip) contains a compiled .exe and a QuakeC build using these extensions. To test them, one can start a coop game and then join it from another instance of vkQuake which can be launched even on the same computer.

How to trigger:
[DP_SV_NODRAWTOCLIENT](https://quakewiki.org/wiki/DP_SV_NODRAWTOCLIENT) - when a monster is hit by an axe, it will become invisible to the attacker.
[DP_SV_DRAWONLYTOCLIENT](https://quakewiki.org/wiki/DP_SV_DRAWONLYTOCLIENT) - when a player's armor is > 0, his/her legs (from [Quake 1.5](https://www.moddb.com/mods/quake-15)) become invisible to other clients.