### PR TITLE
AppImage:  use a  predefined vkquake.desktop  file  

### DIFF
--- a/Misc/vkquake.desktop
+++ b/Misc/vkquake.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories=Game;Shooter;
+Comment=Port of id Software's Quake using the Vulkan API
+Icon=vkquake
+Name=vkQuake
+Terminal=false
+Type=Application
+# no path for AppImage
+Exec=vkquake

--- a/Packaging/AppImage/run-in-docker.sh
+++ b/Packaging/AppImage/run-in-docker.sh
@@ -16,9 +16,9 @@ rm -rf AppDir
 rm -rf vkquake*
 mkdir "$FOLDER"
 ./linuxdeploy-x86_64.AppImage \
-	-e ../../build/appimage/vkquake --appdir=AppDir --create-desktop-file \
+	-e ../../build/appimage/vkquake --appdir=AppDir -d ../../Misc/vkquake.desktop \
 	-i ../../Misc/vkQuake_256.png --icon-filename=vkquake --output appimage
 
-cp "vkquake-$VERSION-x86_64.AppImage" "$FOLDER/vkquake.AppImage"
+cp "vkQuake-$VERSION-x86_64.AppImage" "$FOLDER/vkquake.AppImage"
 cp ../../LICENSE.txt "$FOLDER"
 tar -zcvf "$ARCHIVE" "$FOLDER"


### PR DESCRIPTION
... instead  of a file  automatically  generated by linuxdeploy 

see  https://github.com/Novum/vkQuake/issues/798

