### PR TITLE
MSYS2 32 bit: i686-glslang has been retired and no longer exists in r…

### DIFF
--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -25,7 +25,7 @@ jobs:
         msystem: ${{ matrix.platform.msystem }}
         install: base-devel
           ${{ matrix.platform.msys-env }}-gcc
-          ${{ matrix.platform.msys-env }}-glslang
+          mingw-w64-x86_64-glslang
 
     - uses: actions/checkout@v4
 

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -80,6 +80,10 @@ SYSOBJ_RES = vkQuake.res
 
 LIBWINPTHREAD = $(MSYSTEM_PREFIX)/bin/libwinpthread-1.dll
 
+ifeq ($(wildcard $(GLSLANG)),)
+  GLSLANG := /mingw64/bin/glslangValidator
+endif
+
 # ---------------------------
 # targets / rules
 # ---------------------------


### PR DESCRIPTION
…epos, continue with x86_64 for 32 bits builds

We only need this for calling glslValidator.