### PR TITLE
Updated Vulkan SDK to 1.4.321.1

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Vulkan SDK
       uses: humbletim/install-vulkan-sdk@v1.2
       with:
-        version: 1.3.275.0
+        version: 1.4.321.1
         cache: true
     - name: Build vkQuake
       run: |


### PR DESCRIPTION
 So that --canonicalize-ids is known to spirv-opt (or at least do not create errors if not supported yet)