### PR TITLE
fix clang compile warning with -DNDEBUG

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -883,11 +883,11 @@ For debugging, prints all the entities in the current server
 */
 void ED_PrintEdicts (void)
 {
-	int free_edicts_count = 0;
-	int free_list_count = 0;
-
 	if (!sv.active)
 		return;
+
+	int free_edicts_count = 0;
+	int free_list_count = 0;
 
 	PR_SwitchQCVM (&sv.qcvm);
 


### PR DESCRIPTION
FAILED: [code=1] vkquake.p/Quake_pr_edict.c.o
clang -Ivkquake.p -I. -I.. -I../Quake/mimalloc -I/usr/include/SDL2 -I/usr/include/opus -fdiagnostics-color=always -DNDEBUG -include-pch vkquake.p/quakedef.h.pch -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 -O3 -D_GNU_SOURCE -D_GNU_SOURCE=1 -D_REENTRANT -pthread -Wall -Wno-trigraphs -Werror -std=gnu11 -DUSE_CODEC_WAVE -DUSE_CODEC_MP3 -DUSE_CODEC_FLAC -DUSE_CODEC_VORBIS -DUSE_CODEC_OPUS -MD -MQ vkquake.p/Quake_pr_edict.c.o -MF vkquake.p/Quake_pr_edict.c.o.d -o vkquake.p/Quake_pr_edict.c.o -c ../Quake/pr_edict.c ../Quake/pr_edict.c:886:6: error: variable 'free_edicts_count' set but not used [-Werror,-Wunused-but-set-variable]
  886 |         int free_edicts_count = 0;
      |             ^
../Quake/pr_edict.c:887:6: error: variable 'free_list_count' set but not used [-Werror,-Wunused-but-set-variable]
  887 |         int free_list_count = 0;
      |             ^
2 errors generated.