### PR TITLE
MD5 models : render each mesh independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ Packaging/AppImage/vkquake*
 Packaging/Windows/vkQuake-Installer-*.exe
 Packaging/Windows/vkQuake*.zip
 Misc/vq_pak/mkpak
-Misc/vq_pak/bintoc
+Misc/vq_pak/*.exe
 Misc/vq_pak/*.dSYM
 build/
 .settings

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -34,7 +34,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MZ_REALLOC(p, x) Mem_Realloc (p, x)
 
 // include miniz stb-syle, directly in this compilation unit.
-#define MINIZ_HEADER_FILE_ONLY
+// (supported by miniz)
 #include "miniz.c"
 
 static char *largv[MAX_NUM_ARGVS + 1];

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -344,8 +344,6 @@ typedef struct aliashdr_s
 	int					flags;
 	float				size;
 	int					numindexes;
-	// total nunumindexes in index_buffer, made of the union of this aliashdr_t and all of its nextsurface indexes.
-	int					total_numindexes;
 	int					numverts_vbo;
 	int					numposes;
 	aliashdr_t		   *nextsurface; // spike

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -598,7 +598,7 @@ void R_DrawParticles_ShowTris (cb_context_t *cbx);
 void R_DrawSpriteModel_ShowTris (cb_context_t *cbx, entity_t *e);
 
 void DrawGLPoly (cb_context_t *cbx, glpoly_t *p, float color[3], float alpha);
-void GLMesh_DeleteMeshBuffers (aliashdr_t *hdr);
+void GLMesh_DeleteMeshBuffers (aliashdr_t *mainhdr);
 void GL_MakeAliasModelDisplayLists (qmodel_t *m, aliashdr_t *hdr);
 
 void		Sky_Init (void);

--- a/Shaders/bintoc.c
+++ b/Shaders/bintoc.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 // include miniz stb-syle, directly in this compilation unit.
-#define MINIZ_HEADER_FILE_ONLY
+// (supported by miniz)
 #include "../Quake/miniz.c"
 
 int main (int argc, char **argv)


### PR DESCRIPTION
Rework from #718 : multi-mesh still work but each mesh is rendered separately, so be able to load it's own textures properly and not just the first surface textures, which was working by pure luck before.

This prepares MD3 support, where a model can have multiple surfaces as well, a.k.a "meshes"