### PR TITLE
MD3 : add .skin support

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -256,6 +256,14 @@ char *q_strcasestr (const char *haystack, const char *needle);
 char *q_strlwr (char *str);
 char *q_strupr (char *str);
 
+/* Trim whitespace on both ends, modifying str on-place: Returns the new start of str after trim */
+char *q_strtrim (char *str);
+
+/* Split str around sep, modifying it in-place. The returned char**
+ is the array of resulting sub-strings: subs[k] for k in 0 ..  nb_substr - 1.
+ The returned char** is allocated by Mem_Alloc */
+char **q_strsplit (char *str, char sep, size_t *nb_substr);
+
 // strdup that calls Mem_Alloc
 char *q_strdup (const char *str);
 
@@ -265,7 +273,9 @@ int q_vsnprintf (char *str, size_t size, const char *format, va_list args) FUNC_
 
 //============================================================================
 
-extern THREAD_LOCAL char com_token[1024];
+#define COM_PARSE_MAX_TOKEN_SIZE 4096
+
+extern THREAD_LOCAL char com_token[COM_PARSE_MAX_TOKEN_SIZE];
 extern qboolean			 com_eof;
 
 typedef enum

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -330,6 +330,8 @@ typedef enum
 	PV_SIZE
 } poseverttype_t;
 
+#define MAX_FRAMEGROUPS 4
+
 typedef struct aliashdr_s
 {
 	int					ident;
@@ -353,9 +355,9 @@ typedef struct aliashdr_s
 	aliashdr_t		   *nextsurface; // spike
 	int					numjoints;	 // spike -- for md5
 	poseverttype_t		poseverttype;
-	struct gltexture_s *gltextures[MAX_SKINS][4]; // johnfitz
-	struct gltexture_s *fbtextures[MAX_SKINS][4]; // johnfitz
-	byte			   *texels[MAX_SKINS];		  // only for player skins
+	struct gltexture_s *gltextures[MAX_SKINS][MAX_FRAMEGROUPS]; // johnfitz
+	struct gltexture_s *fbtextures[MAX_SKINS][MAX_FRAMEGROUPS]; // johnfitz
+	byte			   *texels[MAX_SKINS];						// only for player skins
 	VkBuffer			vertex_buffer;
 	glheapallocation_t *vertex_allocation;
 	VkBuffer			index_buffer;
@@ -366,6 +368,37 @@ typedef struct aliashdr_s
 	VkDescriptorSet		joints_set;
 	maliasframedesc_t	frames[1]; // variable sized
 } aliashdr_t;
+
+/*
+==============================================================================
+SKIN DEFINITIONS
+==============================================================================
+*/
+#define MAX_SURFACES 32
+
+typedef struct qpath_str_s
+{
+	char c_str[MAX_QPATH];
+} qpath_str_t;
+
+typedef struct skin_def_s
+{
+	qpath_str_t framegroups[MAX_FRAMEGROUPS];
+	size_t		numframegroups;
+} skin_def_t;
+
+typedef struct surface_def_s
+{
+	qpath_str_t surfname;
+	skin_def_t	skins[MAX_SKINS];
+	size_t		numskins;
+} surface_def_t;
+
+typedef struct all_surfaces_def_s
+{
+	surface_def_t surfaces[MAX_SURFACES];
+	size_t		  numsurfaces;
+} all_surfaces_def_t;
 
 /*
 ==============================================================================
@@ -402,6 +435,7 @@ MD3 MODELS
 #define MD3_VERSION 15
 #define IDMD3HEADER (('I' << 0) | ('D' << 8) | ('P' << 16) | ('3' << 24))
 
+/////////////////////////////////////////////////
 // MD3 vertex+norm file format:
 typedef struct md3XyzNormal_s
 {


### PR DESCRIPTION
Follow-up of https://github.com/Novum/vkQuake/pull/828, adding `.skin` support.

The loading is in 2 passes:

_1. Try either modelname.md3.skin or else modelname.skin :_
   - If found, those are expected to contain __all__ surfaces definitions for the model, pairing surfaces by name with the ones of the model.
   -   One line lists all skins for a single framegroup
   -   Animated textures (framegroups) supported by adding additional lines for a given surface
   -   Order of declaration between different surfaces is irrelevant
  
 Exemple file: surface1 has 2 framegroups with 3 skins, surface2 has 3 framegroups with 1 skin 
```
surface1,progs/s1tex_framegroup_0,progs/s1tex_1_framegroup_0,progs/s1tex_2_framegroup_0 
surface2,progs/s2tex_framegroup_0
surface1,progs/s1tex_framegroup_1,progs/s1tex_1_framegroup_1,progs/s1tex_1_framegroup_1
surface2,progs/s2tex_framegroup_1
surface2,progs/s2tex_framegroup_2
...
```


_2. If not found, lookup modelname.md3_Y.skin or else modelname_Y.skin for upto skin Y in 0 .. MAX_SKINS - 1 :_  (idem https://github.com/andrei-drexler/ironwail/pull/451)
  
   -   Animated textures (framegroups) supported by adding additional lines for a given surface
   -   Order of declaration between different surfaces is irrelevant
 
Exemple file : `modelname.md3_Y.skin`: surface1 skin Y have 2 framegroups, surface2 skin Y have 1 framegroup
```
surface1,progs/s1tex_Y_framegroup_0
surface2,progs/s1tex_Y_framegroup_0
surface1,progs/s1tex_Y_framegroup_1
...
```

The `.skin` definitions are searched first. If none were found, the surface-based and model-based texture names already implemented in https://github.com/Novum/vkQuake/pull/828 are looked up just after.