### PR TITLE
Cont'd #837: Rework replacement models management, cleaner an better …

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -672,8 +672,6 @@ typedef struct qmodel_s
 	//
 	byte *extradata[PV_SIZE]; // only access through Mod_Extradata
 
-	qboolean enhancedmodels_prio; // if true, the MD5/MD3 model has at least as much path priority as the MDL model
-
 	// Ray tracing
 	VkAccelerationStructureKHR blas;
 	VkBuffer				   blas_buffer;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -52,7 +52,7 @@ extern int glwidth, glheight;
 
 #define BACKFACE_EPSILON 0.01
 
-#define MAX_GLTEXTURES				4096
+#define MAX_GLTEXTURES				(16 * 4096)
 #define MAX_SANITY_LIGHTMAPS		256
 #define MIN_NB_DESCRIPTORS_PER_TYPE 32
 


### PR DESCRIPTION
…(hopefully)

Apply the following simple rules:
 - Replacement models are only loaded if the original is MDL
 - Replacement models are only loaded if their path_id is >= MDL, meaning there are either in the same .pak or as in additional path/.pak
 - External resources for a given replacement model are only loaded if their path_id >= replacement model
 - If both MD3 and MD5 replacement models exists, only the one with the highest path_id is loaded, with MD3 chosen in case of equality
 - Removed 'rogue' special treatment, this is not our job to fix Re-release probems and this special rule will bite us later if a mod use 'rogue' as a base...