### PR TITLE
Reset r_skyfog between maps

### DIFF
--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -346,6 +346,7 @@ void Sky_ClearAll (void)
 	solidskytexture = NULL;
 	alphaskytexture = NULL;
 	max_skytexture_index = -1;
+	Cvar_SetQuick (&r_skyfog, r_skyfog.default_string);
 }
 
 /*


### PR DESCRIPTION
Otherwise playing the start map in alkaline, switching to ad, and then loading the ad start map would have different results than just loading the ad start map directly.
From Ironwail/QS