### PR TITLE
Replace descriptor sets with device addresses for animation update compute shaders

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -367,6 +367,7 @@ typedef struct aliashdr_s
 	int					vbostofs; // offset in vbo of hdr->numverts_vbo meshst_t
 	VkBuffer			joints_buffer;
 	glheapallocation_t *joints_allocation;
+	VkDeviceAddress		joints_buffer_address;
 	VkDescriptorSet		joints_set;
 	maliasframedesc_t	frames[1]; // variable sized
 } aliashdr_t;

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1332,6 +1332,7 @@ static void GL_InitDevice (void)
 	GET_GLOBAL_DEVICE_PROC_ADDR (vk_cmd_draw_indexed_indirect, vkCmdDrawIndexedIndirect);
 	GET_GLOBAL_DEVICE_PROC_ADDR (vk_cmd_pipeline_barrier, vkCmdPipelineBarrier);
 	GET_GLOBAL_DEVICE_PROC_ADDR (vk_cmd_copy_buffer_to_image, vkCmdCopyBufferToImage);
+	GET_GLOBAL_DEVICE_PROC_ADDR (vk_cmd_dispatch, vkCmdDispatch);
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -335,7 +335,6 @@ typedef struct
 	VkDescriptorSet			 ray_debug_desc_set;
 	vulkan_desc_set_layout_t ray_debug_set_layout;
 	vulkan_desc_set_layout_t joints_buffer_set_layout;
-	vulkan_desc_set_layout_t anim_compute_set_layout;
 
 	// Scratch buffer for animated AS building (vertex positions + AS build scratch)
 	VkBuffer		scratch_buffer;
@@ -368,6 +367,7 @@ typedef struct
 	PFN_vkCmdDrawIndexedIndirect	vk_cmd_draw_indexed_indirect;
 	PFN_vkCmdPipelineBarrier		vk_cmd_pipeline_barrier;
 	PFN_vkCmdCopyBufferToImage		vk_cmd_copy_buffer_to_image;
+	PFN_vkCmdDispatch				vk_cmd_dispatch;
 	PFN_vkGetBufferDeviceAddressKHR vk_get_buffer_device_address;
 
 	PFN_vkGetAccelerationStructureBuildSizesKHR		   vk_get_acceleration_structure_build_sizes;

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -64,7 +64,6 @@ typedef struct entity_blas_s
 	struct glheapallocation_s *blas_allocation;
 	VkDeviceAddress			   blas_address;
 	VkDeviceSize			   blas_build_scratch_size;
-	VkDescriptorSet			   blas_compute_set;
 	struct qmodel_s			  *blas_model;
 	int						   blas_numtris; // Track triangle count to detect model data changes
 } entity_blas_t;
@@ -164,6 +163,30 @@ typedef struct
 
 	int ambientlight;
 } refdef_t;
+
+typedef struct
+{
+	VkDeviceAddress input_address;
+	VkDeviceAddress output_address;
+	uint32_t		pose1_offset;
+	uint32_t		pose2_offset;
+	uint32_t		output_offset;
+	uint32_t		num_verts;
+	float			blend_factor;
+	uint32_t		flags;
+} mesh_interpolate_push_constants_t;
+
+typedef struct
+{
+	VkDeviceAddress input_address;
+	VkDeviceAddress joints_address;
+	VkDeviceAddress output_address;
+	uint32_t		joints_offset0;
+	uint32_t		joints_offset1;
+	uint32_t		output_offset;
+	uint32_t		num_verts;
+	float			blend_factor;
+} skinning_push_constants_t;
 
 //
 // refresh

--- a/Shaders/mesh_interpolate.comp
+++ b/Shaders/mesh_interpolate.comp
@@ -1,6 +1,8 @@
 #version 460
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 
 // Compute shader for interpolating alias model vertices (MDL/MD3)
 // for acceleration structure building.
@@ -10,36 +12,35 @@
 //
 // The TLAS instance transform handles scale_origin, scale, and entity transform.
 
+layout (buffer_reference, std430) readonly buffer InputVertexBuffer
+{
+	uint data[];
+};
+layout (buffer_reference, std430) writeonly buffer OutputBuffer
+{
+	float data[];
+};
+
 layout (push_constant) uniform PushConsts
 {
-	uint  pose1_offset;	 // Offset in source buffer for pose1 (in vertices)
-	uint  pose2_offset;	 // Offset in source buffer for pose2 (in vertices)
-	uint  output_offset; // Offset in output buffer (in floats)
-	uint  num_verts;
-	float blend_factor;
-	uint  flags; // Bit 2: MD3 format
+	uvec2 input_address;  // 0
+	uvec2 output_address; // 8
+	uint  pose1_offset;	  // 16
+	uint  pose2_offset;	  // 20
+	uint  output_offset;  // 24
+	uint  num_verts;	  // 28
+	float blend_factor;	  // 32
+	uint  flags;		  // 36 (Bit 2: MD3 format)
 }
 push_constants;
 
-// meshxyz_t is 12 bytes: uint16[4] xyz + int8[4] normal
-// We read as uints to get the data
-layout (std430, set = 0, binding = 0) restrict readonly buffer InputVertices
-{
-	uint vertex_data[];
-};
-
-layout (std430, set = 0, binding = 2) restrict writeonly buffer OutputPositions
-{
-	float positions[];
-};
-
 // Decode a meshxyz_t vertex position to model-space coordinates
-vec3 decode_vertex (uint offset)
+vec3 decode_vertex (InputVertexBuffer input_buffer, uint offset)
 {
 	// Each meshxyz_t is 12 bytes = 3 uints
 	// First 8 bytes (2 uints) contain xyz[4] as uint16
-	uint xyz_low = vertex_data[offset * 3];
-	uint xyz_high = vertex_data[offset * 3 + 1];
+	uint xyz_low = input_buffer.data[offset * 3];
+	uint xyz_high = input_buffer.data[offset * 3 + 1];
 
 	// Extract uint16 values
 	float x = float (xyz_low & 0xFFFF);
@@ -71,13 +72,16 @@ void main ()
 	if (vertex_idx >= push_constants.num_verts)
 		return;
 
-	vec3 pos1 = decode_vertex (push_constants.pose1_offset + vertex_idx);
-	vec3 pos2 = decode_vertex (push_constants.pose2_offset + vertex_idx);
+	InputVertexBuffer input_buffer = InputVertexBuffer (push_constants.input_address);
+	OutputBuffer	  output_buffer = OutputBuffer (push_constants.output_address);
+
+	vec3 pos1 = decode_vertex (input_buffer, push_constants.pose1_offset + vertex_idx);
+	vec3 pos2 = decode_vertex (input_buffer, push_constants.pose2_offset + vertex_idx);
 
 	vec3 lerped = mix (pos1, pos2, push_constants.blend_factor);
 
 	uint out_idx = push_constants.output_offset + vertex_idx * 3;
-	positions[out_idx + 0] = lerped.x;
-	positions[out_idx + 1] = lerped.y;
-	positions[out_idx + 2] = lerped.z;
+	output_buffer.data[out_idx + 0] = lerped.x;
+	output_buffer.data[out_idx + 1] = lerped.y;
+	output_buffer.data[out_idx + 2] = lerped.z;
 }

--- a/Shaders/skinning.comp
+++ b/Shaders/skinning.comp
@@ -1,6 +1,8 @@
 #version 460
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 
 // Compute shader for skeletal skinning of MD5 model vertices
 // for acceleration structure building.
@@ -8,13 +10,29 @@
 // Input: md5vert_t vertex data, joint matrices
 // Output: skinned vec3 positions
 
+layout (buffer_reference, std430) readonly buffer InputVertexBuffer
+{
+	float data[];
+};
+layout (buffer_reference, std430) readonly buffer JointMatrixBuffer
+{
+	float data[];
+};
+layout (buffer_reference, std430) writeonly buffer OutputBuffer
+{
+	float data[];
+};
+
 layout (push_constant) uniform PushConsts
 {
-	uint  joints_offset0; // Joint matrix offset for pose 0
-	uint  joints_offset1; // Joint matrix offset for pose 1
-	uint  output_offset;  // Offset in output buffer (in floats)
-	uint  num_verts;
-	float blend_factor;
+	uvec2 input_address;  // 0
+	uvec2 joints_address; // 8
+	uvec2 output_address; // 16
+	uint  joints_offset0; // 24 - Joint matrix offset for pose 0
+	uint  joints_offset1; // 28 - Joint matrix offset for pose 1
+	uint  output_offset;  // 32 - Offset in output buffer (in floats)
+	uint  num_verts;	  // 36
+	float blend_factor;	  // 40
 }
 push_constants;
 
@@ -26,28 +44,14 @@ push_constants;
 // byte joint_indices[4]  - 4 bytes  (offset 36)
 // Total: 40 bytes = 10 floats
 
-layout (std430, set = 0, binding = 0) restrict readonly buffer InputVertices
-{
-	float vertex_data[];
-};
-
-layout (std430, set = 0, binding = 1) restrict readonly buffer JointMatrices
-{
-	float joint_mats[];
-};
-
-layout (std430, set = 0, binding = 2) restrict writeonly buffer OutputPositions
-{
-	float positions[];
-};
-
 // Load a 3x4 joint matrix and transform a position
-vec3 transform_by_joint (vec3 pos, uint joint_offset)
+vec3 transform_by_joint (JointMatrixBuffer joint_mats, vec3 pos, uint joint_offset)
 {
 	uint   base = joint_offset * 12;
 	mat4x3 m = mat4x3 (
-		joint_mats[base + 0], joint_mats[base + 4], joint_mats[base + 8], joint_mats[base + 1], joint_mats[base + 5], joint_mats[base + 9],
-		joint_mats[base + 2], joint_mats[base + 6], joint_mats[base + 10], joint_mats[base + 3], joint_mats[base + 7], joint_mats[base + 11]);
+		joint_mats.data[base + 0], joint_mats.data[base + 4], joint_mats.data[base + 8], joint_mats.data[base + 1], joint_mats.data[base + 5],
+		joint_mats.data[base + 9], joint_mats.data[base + 2], joint_mats.data[base + 6], joint_mats.data[base + 10], joint_mats.data[base + 3],
+		joint_mats.data[base + 7], joint_mats.data[base + 11]);
 	return (m * vec4 (pos, 1.0)).xyz;
 }
 
@@ -58,14 +62,18 @@ void main ()
 	if (vertex_idx >= push_constants.num_verts)
 		return;
 
+	InputVertexBuffer vertex_data = InputVertexBuffer (push_constants.input_address);
+	JointMatrixBuffer joint_mats = JointMatrixBuffer (push_constants.joints_address);
+	OutputBuffer	  positions = OutputBuffer (push_constants.output_address);
+
 	// Read vertex data (40 bytes = 10 floats per vertex)
 	uint base = vertex_idx * 10;
-	vec3 bind_pos = vec3 (vertex_data[base + 0], vertex_data[base + 1], vertex_data[base + 2]);
+	vec3 bind_pos = vec3 (vertex_data.data[base + 0], vertex_data.data[base + 1], vertex_data.data[base + 2]);
 
 	// Joint weights and indices are packed as bytes at offset 32 and 36
 	// That's floats 8 and 9 in our float array
-	uint weights_packed = floatBitsToUint (vertex_data[base + 8]);
-	uint indices_packed = floatBitsToUint (vertex_data[base + 9]);
+	uint weights_packed = floatBitsToUint (vertex_data.data[base + 8]);
+	uint indices_packed = floatBitsToUint (vertex_data.data[base + 9]);
 
 	// Extract weights (normalized bytes)
 	vec4 weights =
@@ -89,7 +97,7 @@ void main ()
 			if (weight > 0.0)
 			{
 				uint joint_idx = indices[i];
-				skinned_pos[frame] += weight * transform_by_joint (bind_pos, frame_offset + joint_idx);
+				skinned_pos[frame] += weight * transform_by_joint (joint_mats, bind_pos, frame_offset + joint_idx);
 			}
 		}
 	}
@@ -99,7 +107,7 @@ void main ()
 
 	// Write output
 	uint out_idx = push_constants.output_offset + vertex_idx * 3;
-	positions[out_idx + 0] = lerped.x;
-	positions[out_idx + 1] = lerped.y;
-	positions[out_idx + 2] = lerped.z;
+	positions.data[out_idx + 0] = lerped.x;
+	positions.data[out_idx + 1] = lerped.y;
+	positions.data[out_idx + 2] = lerped.z;
 }


### PR DESCRIPTION
Otherwise we might reach descriptor pool limits and ray tracing already requires buffer device address.