### PR TITLE
FR #861: animated wind cubmap skies (from Ironwail) 

### DIFF
--- a/Shaders/sky_cube.frag
+++ b/Shaders/sky_cube.frag
@@ -7,6 +7,9 @@ layout (push_constant) uniform PushConsts
 	mat4  mvp;
 	vec3  fog_color;
 	float fog_density;
+	vec3  eye_pos;
+	float wind_phase;
+	vec3  wind_dir;
 }
 push_constants;
 
@@ -18,7 +21,28 @@ layout (location = 0) out vec4 out_frag_color;
 
 void main ()
 {
+	//base color:
 	out_frag_color = texture (tex, in_texcoord.xyz);
+	
+	//add wind:
+	if (push_constants.wind_dir != vec3(0.0f))
+	{	
+		float t1 = push_constants.wind_phase;
+		float t2 = fract(t1) - 0.5;
+		float blend = abs(t1 * 2.0);
+		vec3 dir = normalize(in_texcoord.xyz);
+		vec4 layer1 = texture(tex, dir + t1 * push_constants.wind_dir);
+		vec4 layer2 = texture(tex, dir + t2 * push_constants.wind_dir);
+		layer1.a *= 1.0 - blend;
+		layer2.a *= blend;
+		layer1.rgb *= layer1.a;
+		layer2.rgb *= layer2.a;
+		vec4 combined = layer1 + layer2;
+		
+		//resut:
+		out_frag_color = vec4(out_frag_color.rgb * (1.0 - combined.a) + combined.rgb, 1);
+	}
+    
 	if (push_constants.fog_density > 0.0f)
 		out_frag_color.rgb = (out_frag_color.rgb * (1.0f - push_constants.fog_density)) + (push_constants.fog_color * push_constants.fog_density);
 }


### PR DESCRIPTION
Following #853, I've added  animated cubmap skies, a.k.a "wind", from Ironwail.

Examples can be be found in [Quake Brutalism 3 Jam](https://www.slipseer.com/index.php?resources/quake-brutalist-jam-iii.549/) `start` map, as well as in few others of the pack: `qbj3_h4724`, `qbj3_thatspacepirate` ...etc.

Type `sky` on console to get the skybox name (as before), together with wind parameters, if applicable.

For a given cubemap skybox `sb` in `gfx/env`, we lookup for `gfx/env/sbwind.cfg` containing such a definition:
```c
// distance yaw period pitch
skywind 2 40 65 60
```
Wind toggle is `r_skywind`, `0` to disable animation `1` is the default.