### PR TITLE
Stack and Debugging leftover fixes (some by @j4reporting)

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -16,8 +16,15 @@ jobs:
       run: brew install molten-vk vulkan-headers glslang spirv-tools sdl2 libvorbis flac opus opusfile flac mpg123 meson
     - name: Build vkQuake
       run: meson build --buildtype=${{ matrix.configuration }} -Ddebug=true -Dstrip=false && ninja -C build
+    - name: Extract debug information and bundle it to .dSYM
+      run: |
+        dsymutil build/vkquake -o build/vkquake.dSYM
+        du -sh build/vkquake build/vkquake.dSYM
+        dwarfdump --uuid build/vkquake build/vkquake.dSYM
     - name: Upload vkQuake
       uses: actions/upload-artifact@v4
       with:
         name: vkQuake archive (${{ matrix.configuration }})
-        path: build/vkquake
+        path: |
+          build/vkquake
+          build/vkquake.dSYM

--- a/Packaging/AppImage/run-in-docker.sh
+++ b/Packaging/AppImage/run-in-docker.sh
@@ -15,7 +15,7 @@ cd Packaging/AppImage
 rm -rf AppDir
 rm -rf vkquake*
 mkdir "$FOLDER"
-./linuxdeploy-x86_64.AppImage \
+NO_STRIP=1 ./linuxdeploy-x86_64.AppImage \
 	-e ../../build/appimage/vkquake --appdir=AppDir -d ../../Misc/vkquake.desktop \
 	-i ../../Misc/vkQuake_256.png --icon-filename=vkquake --output appimage
 

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -172,21 +172,20 @@ void Sys_Init (void)
 
 	SymSetOptions (SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_NO_PROMPTS | SYMOPT_DEFERRED_LOADS);
 
-	if (!SymInitialize (process, NULL, TRUE))
-	{
-		SymCleanup (process);
-	}
-	else
+	if (SymInitialize (process, NULL, TRUE))
 		win32_DbgHelp_init_success = true;
 
 	// MSYS2 DWARF debug info is only usable if the stack addresses are offseted
 	// by win32_Dwarf_offset
-	// We need to look for the binary executable itself to look for the original ImageBase:
+	// We need to look for the executable to look for the original ImageBase in the binary
+	// ifself BEFORE it got patched in the loaded image...
+	// this is the address we would get by : objdump -p vkQuake.exe | grep ImageBase
 	wchar_t path[MAX_OSPATH];
 
 	if (GetModuleFileNameW (NULL, path, MAX_OSPATH))
 	{
-		HANDLE hSelfExecutable = CreateFileW (path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+		HANDLE hSelfExecutable =
+			CreateFileW (path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
 		if (hSelfExecutable != INVALID_HANDLE_VALUE)
 		{


### PR DESCRIPTION
- Windows DbgHelp : even safer API calls
- Linux CI : Forbid Linuxdeploy to strip debug info from generated binaries (by @j4reporting)
- MacOS : Debug info is extracted and bundled in .dSYM, add it in the artifact