### PR TITLE
fix GCC 15 warnings

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1481,7 +1481,7 @@ static void Host_Loadgame_f (void)
 			char	   *end;
 			const char *ext;
 			ext = data + 2;
-			while ((end = strchr (ext, '\n')))
+			while ((end = (char *)strchr (ext, '\n')))
 			{
 				*end = 0;
 				ext = COM_Parse (ext);

--- a/Quake/net_udp.c
+++ b/Quake/net_udp.c
@@ -476,7 +476,7 @@ int UDP_GetNameFromAddr (struct qsockaddr *addr, char *name)
 int UDP4_GetAddrFromName (const char *name, struct qsockaddr *addr)
 {
 	struct hostent *hostentry;
-	char		   *colon;
+	const char	   *colon;
 	unsigned short	port = net_hostport;
 
 	if (name[0] >= '0' && name[0] <= '9')
@@ -731,7 +731,7 @@ int UDP6_GetAddrFromName (const char *name, struct qsockaddr *addr)
 	struct addrinfo *pos;
 	struct addrinfo	 udp6hint;
 	int				 error;
-	char			*port;
+	const char		*port;
 	char			 dupbase[256];
 	size_t			 len;
 	qboolean		 success = false;

--- a/Quake/r_part_fte.c
+++ b/Quake/r_part_fte.c
@@ -802,7 +802,7 @@ static part_type_t *P_GetParticleType (const char *config, const char *name)
 	part_type_t *ptype;
 	part_type_t *oldlist = part_type;
 	char		 cfgbuf[MAX_QPATH];
-	char		*dot = strchr (name, '.');
+	const char	*dot = strchr (name, '.');
 	if (dot && (dot - name) < MAX_QPATH - 1)
 	{
 		config = cfgbuf;
@@ -908,7 +908,7 @@ int PScript_FindParticleType (const char *fullname)
 	int			 i;
 	part_type_t *ptype = NULL;
 	char		 cfg[MAX_QPATH];
-	char		*dot;
+	const char	*dot;
 	const char	*name = fullname;
 
 	// check particle aliases, mostly for tex_sky1 -> weather.te_rain for example, or whatever


### PR DESCRIPTION
On Arch Linux I was getting a bunch of

    error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]

for strstr, strchr, and strrchr.

The reason is most likely the new compiler -  "cc (GCC) 15.2.1 20260209".