### PR TITLE
add missing check for ENTALPHA_DEFAULT in R_IsEntityTransparent

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -444,7 +444,7 @@ static qboolean R_IsEntityTransparent (entity_t *e, qboolean *opaque_with_transp
 {
 	qboolean transparent = ENTALPHA_DECODE (e->alpha) != 1;
 	*opaque_with_transparent_water =
-		(!transparent && e->model->type == mod_brush && e->model->used_specials & SURF_DRAWTURB &&
+		(!transparent && e->model->type == mod_brush && e->model->used_specials & SURF_DRAWTURB && e->alpha == ENTALPHA_DEFAULT &&
 		 ((e->model->used_specials & SURF_DRAWLAVA && (map_lavaalpha > 0 ? map_lavaalpha : map_fallbackalpha) != 1) ||
 		  (e->model->used_specials & SURF_DRAWTELE && (map_telealpha > 0 ? map_telealpha : map_fallbackalpha) != 1) ||
 		  (e->model->used_specials & SURF_DRAWSLIME && (map_slimealpha > 0 ? map_slimealpha : map_fallbackalpha) != 1) ||

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -60,8 +60,6 @@ extern cvar_t r_tasks;
 extern cvar_t r_parallelmark;
 extern cvar_t r_usesops;
 
-extern cvar_t r_drawwater_fast;
-
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
 #endif
@@ -3726,8 +3724,6 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_tasks);
 	Cvar_RegisterVariable (&r_parallelmark);
 	Cvar_RegisterVariable (&r_usesops);
-
-	Cvar_RegisterVariable (&r_drawwater_fast);
 
 	R_InitParticles ();
 	SetClearColor (); // johnfitz

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -38,11 +38,6 @@ extern cvar_t vid_palettize;
 
 cvar_t r_parallelmark = {"r_parallelmark", "1", CVAR_NONE};
 
-// vso - in some cases, R_DrawTextureChains_Water oprimization
-// make some surfaces not rendered. Since this optimization does not seem
-// to actually impact performance disable it by default for now.
-cvar_t r_drawwater_fast = {"r_drawwater_fast", "0", CVAR_ARCHIVE};
-
 byte *SV_FatPVS (vec3_t org, qmodel_t *worldmodel);
 
 extern VkBuffer bmodel_vertex_buffer;
@@ -1191,21 +1186,8 @@ void R_DrawTextureChains_Water (cb_context_t *cbx, qmodel_t *model, entity_t *en
 		const float	   alpha = GL_WaterAlphaForEntitySurface (ent, t->texturechains[chain]);
 		const qboolean alpha_blend = alpha < 1.0f;
 
-		// vso - water-like surfaces are in some cases rendered incorrectly,
-		// disabling this path solves the issue.
-		if (r_drawwater_fast.value > 0.0f)
-		{
-			if (alpha_blend)
-			{
-				if (opaque_only && (!r_lightmap_cheatsafe || !indirect))
-					continue;
-			}
-			else
-			{
-				if (transparent_only && (!r_lightmap_cheatsafe || !indirect))
-					continue;
-			}
-		}
+		if (((opaque_only && alpha_blend) || (transparent_only && !alpha_blend)) && (!r_lightmap_cheatsafe || !indirect))
+			continue;
 
 		gltexture_t *gl_texture = t->warpimage;
 		if (!r_lightmap_cheatsafe)


### PR DESCRIPTION
add missing check for ENTALPHA_DEFAULT
  otherwise,  water entities with a fixed alpha value of 1.0f might inherit the
  current value of r_wateralpha < 1.0  and be consodered transparent.

resolves  https://github.com/Novum/vkQuake/issues/767
