### PR TITLE
COM_CreatePath: handle backslash path separators on Windows

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1906,11 +1906,12 @@ void COM_CreatePath (char *path)
 
 	for (ofs = path + 1; *ofs; ofs++)
 	{
-		if (*ofs == '/')
+		if (IS_DIR_SEPARATOR (*ofs))
 		{ // create the directory
+			char sep = *ofs;
 			*ofs = 0;
 			Sys_mkdir (path);
-			*ofs = '/';
+			*ofs = sep;
 		}
 	}
 }


### PR DESCRIPTION
COM_CreatePath only checked for '/' when creating intermediate directories, so paths with '\' separators (e.g. from condump with subdirectories) would fail to create the directory tree on Windows.

Use the existing IS_DIR_SEPARATOR() macro (from ilenames.h, already included) which handles both '/' and '\\' on Windows while remaining '/'-only on Unix. Also preserve the original separator character instead of always restoring '/'.

**Reproduction:**
1. Launch vkQuake on Windows
2. Open console, type condump subdir\test.txt
3. The file fails to create because COM_CreatePath doesn't create the subdir directory (only checks /)

**Verification:** Builds clean (MSVC x64 Release, 0 warnings, 0 errors), passes clang-format.