### PR TITLE
Add missing some QSS extensions

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -28,8 +28,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // references them even when on a unix system.
 
 // these two are not intended to be set directly
-cvar_t cl_name = {"_cl_name", "player", CVAR_ARCHIVE};
-cvar_t cl_color = {"_cl_color", "0", CVAR_ARCHIVE};
+cvar_t cl_name = {"_cl_name", "player", CVAR_ARCHIVE | CVAR_USERINFO};
+
+cvar_t cl_topcolor = {"topcolor", "0", CVAR_ARCHIVE | CVAR_USERINFO};
+cvar_t cl_bottomcolor = {"bottomcolor", "0", CVAR_ARCHIVE | CVAR_USERINFO};
 
 cvar_t cl_shownet = {"cl_shownet", "0", CVAR_NONE}; // can be 0, 1, or 2
 cvar_t cl_nolerp = {"cl_nolerp", "0", CVAR_NONE};
@@ -268,7 +270,7 @@ void CL_SignonReply (void)
 
 	case 2:
 		MSG_WriteByte (&cls.message, clc_stringcmd);
-		MSG_WriteString (&cls.message, va ("color %i %i\n", ((int)cl_color.value) >> 4, ((int)cl_color.value) & 0x0f));
+		MSG_WriteString (&cls.message, va ("color %i %i\n", (int)cl_topcolor.value, (int)cl_bottomcolor.value));
 
 		if (*cl.serverinfo)
 			Info_Enumerate (cls.userinfo, CL_SendInitialUserinfo, NULL);
@@ -1194,6 +1196,126 @@ static void CL_ServerExtension_UserinfoUpdate_f (void)
 	}
 }
 
+static void SV_DecodeUserInfo (client_t *client)
+{
+	char tmp[64];
+	int	 top, bot;
+
+	// figure out the player's colours
+	Info_GetKey (client->userinfo, "topcolor", tmp, sizeof (tmp));
+	top = atoi (tmp) & 15;
+	if (top > 13)
+		top = 13;
+	Info_GetKey (client->userinfo, "bottomcolor", tmp, sizeof (tmp));
+	bot = atoi (tmp) & 15;
+	if (bot > 13)
+		bot = 13;
+	// update their entity
+	client->edict->v.team = bot + 1;
+	client->colors = (top << 4) | bot;
+
+	// pick out a name and try to clean it up a little.
+	Info_GetKey (client->userinfo, "name", tmp, sizeof (tmp));
+
+	if (!*tmp)
+		q_strlcpy (tmp, "unnamed", sizeof (tmp));
+
+	if (strcmp (client->name, tmp) != 0)
+	{ // name changed.
+		if (client->name[0] && strcmp (client->name, "unconnected"))
+			Con_DPrintf ("\"%s\" renamed to \"%s\"\n", host_client->name, tmp);
+		strcpy (host_client->name, tmp);
+
+		client->edict->v.netname = PR_SetEngineString (client->name);
+	}
+}
+void SV_UpdateInfo (int edict, const char *keyname, const char *value)
+{
+	char oldvalue[1024];
+
+	char	   *info;
+	size_t		infosize;
+	const char *pre;
+	client_t   *infoplayer = NULL;
+
+	if (!edict)
+	{
+		cvar_t *var = Cvar_FindVar (keyname);
+		if (var && var->flags & CVAR_SERVERINFO)
+		{
+			Cvar_Set (var->name, value);
+			return;
+		}
+		info = svs.serverinfo;
+		infosize = sizeof (svs.serverinfo);
+		pre = "//svi ";
+	}
+	else if (edict <= svs.maxclients)
+	{
+		edict -= 1;
+		infoplayer = &svs.clients[edict];
+		info = infoplayer->userinfo;
+		infosize = sizeof (infoplayer->userinfo);
+		pre = va ("//ui %i", edict);
+	}
+	else
+		return;
+
+	Info_GetKey (info, keyname, oldvalue, sizeof (oldvalue));
+
+	if (strcmp (value, oldvalue))
+	{
+		// its changed. actually broadcast it.
+		Info_SetKey (info, infosize, keyname, value);
+
+		if (infoplayer)
+			SV_DecodeUserInfo (infoplayer);
+
+		if (*keyname == '_' || !sv.active)
+			return; // underscore means private (user) keys. these are not networked to clients.
+
+		Info_GetKey (info, keyname, oldvalue, sizeof (oldvalue));
+		value = oldvalue;
+
+		for (client_t *current_client = svs.clients; current_client < svs.clients + svs.maxclients; current_client++)
+		{
+			if (current_client->active)
+			{
+				if (current_client->protocol_pext2 & PEXT2_PREDINFO)
+				{
+					MSG_WriteByte (&current_client->message, svc_stufftext);
+					MSG_WriteString (&current_client->message, va ("%s \"%s\" \"%s\"\n", pre, keyname, value));
+				}
+				else if (infoplayer && !strcmp (keyname, "name"))
+				{
+					MSG_WriteByte (&current_client->message, svc_updatename);
+					MSG_WriteByte (&current_client->message, edict);
+					MSG_WriteString (&current_client->message, value);
+				}
+				else if (infoplayer && (!strcmp (keyname, "topcolor") || !strcmp (keyname, "bottomcolor")))
+				{
+					MSG_WriteByte (&current_client->message, svc_updatecolors);
+					MSG_WriteByte (&current_client->message, edict);
+					MSG_WriteByte (&current_client->message, infoplayer->colors);
+				}
+			}
+		}
+	}
+}
+
+static void CL_ServerExtension_Ignore_f (void)
+{
+	Con_DPrintf2 ("Ignoring stufftext: %s\n", Cmd_Argv (0));
+}
+
+static void CL_LegacyColor_f (void)
+{
+	// spike -- code to handle the legacy _cl_color cvar (we now use separate qw-style topcolor/bottomcolor userinfo cvars)
+	int col = atoi (Cmd_Argv (1));
+	Cvar_SetValue ("topcolor", (col >> 4) & 0xf);
+	Cvar_SetValue ("bottomcolor", (col >> 0) & 0xf);
+}
+
 /*
 =================
 CL_Init
@@ -1207,7 +1329,9 @@ void CL_Init (void)
 	CL_InitTEnts ();
 
 	Cvar_RegisterVariable (&cl_name);
-	Cvar_RegisterVariable (&cl_color);
+	Cvar_RegisterVariable (&cl_topcolor);
+	Cvar_RegisterVariable (&cl_bottomcolor);
+	Cmd_AddCommand ("_cl_color", CL_LegacyColor_f); // for loading vanilla configs (we have separate qw-style topcolor/bottomcolor userinfo cvars instead)
 	Cvar_RegisterVariable (&cl_upspeed);
 	Cvar_RegisterVariable (&cl_forwardspeed);
 	Cvar_RegisterVariable (&cl_backspeed);
@@ -1254,4 +1378,20 @@ void CL_Init (void)
 	// spike -- userinfo stuff
 	Cmd_AddCommand_ServerCommand ("fui", CL_ServerExtension_FullUserinfo_f);
 	Cmd_AddCommand_ServerCommand ("ui", CL_ServerExtension_UserinfoUpdate_f);
+
+	Cmd_AddCommand_ServerCommand ("paknames", CL_ServerExtension_Ignore_f);		 // package names in use by the server (including gamedir+extension)
+	Cmd_AddCommand_ServerCommand ("paks", CL_ServerExtension_Ignore_f);			 // provides hashes to go with the paknames list
+	Cmd_AddCommand_ServerCommand ("wps", CL_ServerExtension_Ignore_f);			 // ktx/cspree weapon stats
+	Cmd_AddCommand_ServerCommand ("it", CL_ServerExtension_Ignore_f);			 // cspree item timers
+	Cmd_AddCommand_ServerCommand ("tinfo", CL_ServerExtension_Ignore_f);		 // ktx team info
+	Cmd_AddCommand_ServerCommand ("exectrigger", CL_ServerExtension_Ignore_f);	 // spike
+	Cmd_AddCommand_ServerCommand ("csqc_progname", CL_ServerExtension_Ignore_f); // spike
+	Cmd_AddCommand_ServerCommand ("csqc_progsize", CL_ServerExtension_Ignore_f); // spike
+	Cmd_AddCommand_ServerCommand ("csqc_progcrc", CL_ServerExtension_Ignore_f);	 // spike
+	Cmd_AddCommand_ServerCommand ("cl_fullpitch", CL_ServerExtension_Ignore_f);	 // spike
+	Cmd_AddCommand_ServerCommand ("pq_fullpitch", CL_ServerExtension_Ignore_f);	 // spike
+
+	Cmd_AddCommand_ServerCommand ("cl_serverextension_download", CL_ServerExtension_Ignore_f); // spike
+	Cmd_AddCommand_ServerCommand ("cl_downloadbegin", CL_ServerExtension_Ignore_f);			   // spike
+	Cmd_AddCommand_ServerCommand ("cl_downloadfinished", CL_ServerExtension_Ignore_f);		   // spike
 }

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // client.h
 
+#define CLIENT_USER_INFO_STRING_SIZE 8192
+
 typedef struct
 {
 	int	 length;
@@ -42,7 +44,7 @@ typedef struct
 	int	  ping;
 	byte  translations[VID_GRADES * 256];
 
-	char userinfo[8192];
+	char userinfo[CLIENT_USER_INFO_STRING_SIZE];
 } scoreboard_t;
 
 typedef struct
@@ -143,7 +145,7 @@ typedef struct
 	struct qsocket_s *netcon;
 	sizebuf_t		  message; // writing buffer to send to server
 
-	char userinfo[8192];
+	char userinfo[CLIENT_USER_INFO_STRING_SIZE];
 } client_static_t;
 
 extern client_static_t cls;
@@ -279,14 +281,15 @@ typedef struct
 	float zoom;
 	float zoomdir;
 
-	char serverinfo[8192]; // \key\value infostring data.
+	char serverinfo[SERVER_INFO_STRING_SIZE]; // \key\value infostring data.
 } client_state_t;
 
 //
 // cvars
 //
 extern cvar_t cl_name;
-extern cvar_t cl_color;
+
+extern cvar_t cl_topcolor, cl_bottomcolor;
 
 extern cvar_t cl_upspeed;
 extern cvar_t cl_forwardspeed;
@@ -358,6 +361,8 @@ void CL_Signon4 (void);
 void CL_Disconnect (void);
 void CL_Disconnect_f (void);
 void CL_NextDemo (void);
+
+void SV_UpdateInfo (int edict, const char *keyname, const char *value);
 
 //
 // cl_input

--- a/Quake/cvar.c
+++ b/Quake/cvar.c
@@ -114,17 +114,44 @@ void Cvar_Set_f (void)
 	const char *varname = Cmd_Argv (1);
 	const char *varvalue = Cmd_Argv (2);
 	cvar_t	   *var;
+	int			fl = 0;
+
 	if (Cmd_Argc () < 3)
 	{
 		Con_Printf ("%s <cvar> <value>\n", Cmd_Argv (0));
 		return;
 	}
-	if (Cmd_Argc () > 3)
+
+	if (!strcmp (Cmd_Argv (0), "setfl") && Cmd_Argc () == 4)
+	{
+		const char *as = Cmd_Argv (3);
+		for (; *as; as++)
+		{
+			switch (*as)
+			{
+			case 'a':
+				fl |= CVAR_ARCHIVE | CVAR_SETA; // will forget other flags, but that's probably okay because this should be more for default.cfg and the other
+												// flags will get re-asserted that way anyway
+				break;
+			case 'u':
+				fl |= CVAR_USERINFO;
+				break;
+			case 's':
+				fl |= CVAR_SERVERINFO;
+				break;
+			default:
+				Con_Warning ("%s \"%s\" unknown cvar flag '%c'\n", Cmd_Argv (0), varname, *as);
+				return;
+			}
+		}
+	}
+	else if (Cmd_Argc () > 3)
 	{
 		Con_Warning ("%s \"%s\" command with extra args\n", Cmd_Argv (0), varname);
 		return;
 	}
 	var = Cvar_Create (varname, varvalue);
+	var->flags |= fl;
 	Cvar_SetQuick (var, varvalue);
 
 	if (!strcmp (Cmd_Argv (0), "seta"))
@@ -477,6 +504,38 @@ void Cvar_SetQuick (cvar_t *var, const char *value)
 		var->callback (var);
 	if (var->flags & CVAR_AUTOCVAR)
 		PR_AutoCvarChanged (var);
+
+	if (var->flags & CVAR_SERVERINFO)
+	{
+		// replicate the cvar change into the serverinfo string and let clients know.
+		Info_SetKey (svs.serverinfo, sizeof (svs.serverinfo), var->name, var->string);
+
+		for (client_t *current_client = svs.clients; current_client < svs.clients + svs.maxclients; current_client++)
+		{
+			if (current_client->active)
+			{
+				MSG_WriteByte (&current_client->message, svc_stufftext);
+				MSG_WriteString (&current_client->message, va ("%s \"%s\" \"%s\"\n", "//svi", var->name, var->string));
+			}
+		}
+	}
+	if (var->flags & CVAR_USERINFO)
+	{
+		// replicate the cvar change into the userinfo.
+		Info_SetKey (cls.userinfo, sizeof (cls.userinfo), var->name, var->string);
+
+		// let the server know.
+		if (cls.state == ca_connected)
+		{
+			MSG_WriteByte (&cls.message, clc_stringcmd);
+			if (var == &cl_name) // some hacks for legacy settings.
+				MSG_WriteString (&cls.message, va ("name \"%s\"\n", var->string));
+			else if (var == &cl_topcolor || var == &cl_bottomcolor)
+				MSG_WriteString (&cls.message, va ("color \"%s\" \"%s\"\n", cl_topcolor.string, cl_bottomcolor.string));
+			else
+				MSG_WriteString (&cls.message, va ("setinfo \"%s\" \"%s\"\n", var->name, var->string));
+		}
+	}
 }
 
 void Cvar_SetValueQuick (cvar_t *var, const float value)

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -34,6 +34,8 @@ extern cvar_t pausable;
 extern cvar_t nomonsters;
 extern cvar_t autoload;
 extern cvar_t autofastload;
+extern cvar_t cl_topcolor;
+extern cvar_t cl_bottomcolor;
 
 int current_skill;
 
@@ -1710,7 +1712,7 @@ static void Host_Name_f (void)
 	if (host_client->name[0] && strcmp (host_client->name, "unconnected"))
 	{
 		if (strcmp (host_client->name, newName) != 0)
-			Con_Printf ("%s renamed to %s\n", host_client->name, newName);
+			Con_DPrintf ("\"%s\" renamed to \"%s\"\n", host_client->name, newName);
 	}
 	strcpy (host_client->name, newName);
 	host_client->edict->v.netname = PR_SetEngineString (host_client->name);
@@ -1877,48 +1879,36 @@ Host_Color_f
 */
 static void Host_Color_f (void)
 {
-	int top, bottom;
-	int playercolor;
+	const char *top, *bottom;
 
 	if (Cmd_Argc () == 1)
 	{
-		Con_Printf ("\"color\" is \"%i %i\"\n", ((int)cl_color.value) >> 4, ((int)cl_color.value) & 0x0f);
+		// TODO : do better and print color names instead like QSS ?
+		Con_Printf ("\"color\" is \"%i %i\"\n", (int)cl_topcolor.value, (int)cl_bottomcolor.value);
 		Con_Printf ("color <0-13> [0-13]\n");
 		return;
 	}
 
 	if (Cmd_Argc () == 2)
-		top = bottom = atoi (Cmd_Argv (1));
+		top = bottom = Cmd_Argv (1);
 	else
 	{
-		top = atoi (Cmd_Argv (1));
-		bottom = atoi (Cmd_Argv (2));
+		top = Cmd_Argv (1);
+		bottom = Cmd_Argv (2);
 	}
-
-	top &= 15;
-	if (top > 13)
-		top = 13;
-	bottom &= 15;
-	if (bottom > 13)
-		bottom = 13;
-
-	playercolor = top * 16 + bottom;
 
 	if (cmd_source != src_client)
 	{
-		Cvar_SetValue ("_cl_color", playercolor);
+		Cvar_Set ("topcolor", top);
+		Cvar_Set ("bottomcolor", bottom);
+
 		if (cls.state == ca_connected)
 			Cmd_ForwardToServer ();
 		return;
 	}
 
-	host_client->colors = playercolor;
-	host_client->edict->v.team = bottom + 1;
-
-	// send notification to all clients
-	MSG_WriteByte (&sv.reliable_datagram, svc_updatecolors);
-	MSG_WriteByte (&sv.reliable_datagram, host_client - svs.clients);
-	MSG_WriteByte (&sv.reliable_datagram, host_client->colors);
+	SV_UpdateInfo ((host_client - svs.clients) + 1, "topcolor", top);
+	SV_UpdateInfo ((host_client - svs.clients) + 1, "bottomcolor", bottom);
 }
 
 /*
@@ -2699,6 +2689,137 @@ void Host_Resetdemos (void)
 	cls.demonum = 0;
 }
 
+static void Info_ClientPrint_Callback (void *ctx, const char *key, const char *val)
+{
+	SV_ClientPrintf ("%20s: %s\n", key, val);
+}
+
+static void Host_Serverinfo_f (void)
+{
+	// serverinfo command
+	if (cmd_source == src_client)
+	{
+		Info_Enumerate (svs.serverinfo, Info_ClientPrint_Callback, NULL);
+		return;
+	}
+	if (Cmd_Argc () != 3)
+	{
+		Con_Printf ("Serverinfo:\n");
+		if (cls.state >= ca_connected && cmd_source != src_client)
+			Info_Print (cl.serverinfo);
+		else
+			Info_Print (svs.serverinfo);
+	}
+	else if (cmd_source == src_command)
+	{
+		const char *key = Cmd_Argv (1);
+		const char *val = Cmd_Argv (2);
+		if (*key == '*')
+		{
+			Con_Printf ("Refusing to set key \"%s\"\n", key);
+			return;
+		}
+		SV_UpdateInfo (0, key, val);
+	}
+	else
+		Con_Printf ("Serverinfo may not be changed here\n");
+}
+
+static void Host_Setinfo_f (void)
+{
+	const char *key = Cmd_Argv (1);
+	const char *val = Cmd_Argv (2);
+
+	if (cmd_source == src_client)
+	{ // clc_stringcmd version
+		if (Cmd_Argc () != 3)
+		{
+			SV_ClientPrintf ("Your Serverside User Info:\n");
+			Info_Enumerate (host_client->userinfo, Info_ClientPrint_Callback, NULL);
+		}
+		else
+		{
+			if (*key == '*')
+				return; // users may not change * keys (beyond initial connection anyway).
+			SV_UpdateInfo ((host_client - svs.clients) + 1, key, val);
+		}
+	}
+	else
+	{ // console version
+		if (Cmd_Argc () != 3)
+		{
+			Con_Printf ("User Info:\n");
+			Info_Print (cls.userinfo);
+		}
+		else
+		{
+			cvar_t *var = Cvar_FindVar (key);
+			if (var && var->flags & CVAR_USERINFO)
+				Cvar_Set (key, val);
+			else
+			{
+				Info_SetKey (cls.userinfo, sizeof (cls.userinfo), key, val);
+				if (cls.state == ca_connected)
+					Cmd_ForwardToServer ();
+			}
+		}
+	}
+}
+static void Host_User_f (void)
+{
+	/*if (sv.active)
+	{
+		int i;
+		if (Cmd_Argc() == 2)
+		{
+			i = atoi(Cmd_Argv(1));
+
+			if (i >= cl.maxclients)
+				return;	//not a valid slot.
+
+			Con_Printf("User %i (%s):\n", i, svs.clients[i].name);
+			Info_Print(svs.clients[i].userinfo);
+		}
+		else
+		{
+			for (i = 0; i < svs.maxclients; i++)
+			{
+				if (*svs.clients[i].name)
+				{
+					Con_Printf("User %i (%s):\n", i, svs.clients[i].name);
+					Info_Print(svs.clients[i].userinfo);
+				}
+			}
+		}
+	}
+	else*/
+	if (cls.state == ca_connected)
+	{
+		int i;
+		if (Cmd_Argc () == 2)
+		{
+			i = atoi (Cmd_Argv (1));
+
+			if (i >= cl.maxclients)
+				return; // not a valid slot.
+
+			Con_Printf ("User %i (%s):\n", i, cl.scores[i].name);
+			Info_Print (cl.scores[i].userinfo);
+		}
+		else
+		{
+			for (i = 0; i < cl.maxclients; i++)
+			{
+				if (*cl.scores[i].name)
+				{
+					Con_Printf ("User %i (%s):\n", i, cl.scores[i].name);
+					Info_Print (cl.scores[i].userinfo);
+				}
+			}
+		}
+	}
+}
+
 //=============================================================================
 
 /*
@@ -2713,6 +2834,10 @@ void Host_InitCommands (void)
 	Cmd_AddCommand ("games", Host_Mods_f);		// as an alias to "mods" -- S.A. / QuakeSpasm
 	Cmd_AddCommand ("mapname", Host_Mapname_f); // johnfitz
 	Cmd_AddCommand ("randmap", Host_Randmap_f); // ericw
+
+	Cmd_AddCommand_ClientCommand ("serverinfo", Host_Serverinfo_f); // spike
+	Cmd_AddCommand_ClientCommand ("setinfo", Host_Setinfo_f);		// spike
+	Cmd_AddCommand ("user", Host_User_f);							// spike
 
 	Cmd_AddCommand ("status", Host_Status_f);
 	Cmd_AddCommand ("quit", Host_Quit_f);

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1097,8 +1097,8 @@ static void M_Menu_Setup_f (void)
 	m_entersound = true;
 	strcpy (setup_myname, cl_name.string);
 	strcpy (setup_hostname, hostname.string);
-	setup_top = setup_oldtop = ((int)cl_color.value) >> 4;
-	setup_bottom = setup_oldbottom = ((int)cl_color.value) & 15;
+	setup_top = setup_oldtop = ((int)cl_topcolor.value);
+	setup_bottom = setup_oldbottom = ((int)cl_bottomcolor.value);
 }
 
 static void M_Setup_Draw (cb_context_t *cbx)

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -32,8 +32,6 @@ char *PR_GetTempString (void)
 	return pr_string_temp[(STRINGTEMP_BUFFERS - 1) & ++pr_string_tempindex];
 }
 
-#define RETURN_EDICT(e) (((int *)qcvm->globals)[OFS_RETURN] = EDICT_TO_PROG (e))
-
 /*
 ===============================================================================
 

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -2998,6 +2998,250 @@ static void PF_cl_localsound (void)
 }
 // file stuff
 
+// returns false if the file is denied.
+// fallbackread can be NULL, if the qc is not allowed to read that (original) file at all.
+static qboolean QC_FixFileName (const char *name, const char **result, const char **fallbackread)
+{
+	if (!*name ||			   // blank names are bad
+		strchr (name, ':') ||  // dos/win absolute path, ntfs ADS, amiga drives. reject them all.
+		strchr (name, '\\') || // windows-only paths.
+		*name == '/' ||		   // absolute path was given - reject
+		strstr (name, ".."))   // someone tried to be clever.
+	{
+		return false;
+	}
+
+	*fallbackread = name;
+	// if its a user config, ban any fallback locations so that csqc can't read passwords or whatever.
+	if ((!strchr (name, '/') || q_strncasecmp (name, "configs/", 8)) && !q_strcasecmp (COM_FileGetExtension (name), "cfg") &&
+		q_strncasecmp (name, "particles/", 10) && q_strncasecmp (name, "huds/", 5) && q_strncasecmp (name, "models/", 7))
+		*fallbackread = NULL;
+	*result = va ("data/%s", name);
+	return true;
+}
+
+// small note on access modes:
+// when reading, we fopen files inside paks, for compat with (crappy non-zip-compatible) filesystem code
+// when writing, we directly fopen the file such that it can never be inside a pak.
+// this means that we need to take care when reading in order to detect EOF properly.
+// writing doesn't need anything like that, so it can just dump stuff out, but we do need to ensure that the modes don't get mixed up, because trying to read
+// from a writable file will not do what you would expect. even libc mandates a seek between reading+writing, so no great loss there.
+static struct qcfile_s
+{
+	qcvm_t *owningvm;
+	char	cache[1024];
+	int		cacheoffset, cachesize;
+	FILE   *file;
+	int		fileoffset;
+	int		filesize;
+	int		filebase; // the offset of the file inside a pak
+	int		mode;
+} *qcfiles;
+
+static size_t qcfiles_max;
+
+#define QC_FILE_BASE 1
+
+static void PF_fopen (void)
+{
+	const char *fname = G_STRING (OFS_PARM0);
+	int			fmode = G_FLOAT (OFS_PARM1);
+	const char *fallback;
+	FILE	   *file;
+	size_t		i;
+	char		name[MAX_OSPATH], *sl;
+	int			filesize = 0;
+
+	G_FLOAT (OFS_RETURN) = -1; // assume failure
+
+	if (!QC_FixFileName (fname, &fname, &fallback))
+	{
+		Con_Printf ("qcfopen: Access denied: %s\n", fname);
+		return;
+	}
+	// if we were told to use 'foo.txt'
+	// fname is now 'data/foo.txt'
+	// fallback is now 'foo.txt', and must ONLY be read.
+
+	switch (fmode)
+	{
+	case 0: // read
+		filesize = COM_FOpenFile (fname, &file, NULL);
+		if (!file && fallback)
+			filesize = COM_FOpenFile (fallback, &file, NULL);
+		break;
+	case 1: // append
+		q_snprintf (name, sizeof (name), "%s/%s", com_gamedir, fname);
+		Sys_mkdir (name);
+		file = fopen (name, "w+b");
+		if (file)
+			fseek (file, 0, SEEK_END);
+		break;
+	case 2: // write
+		q_snprintf (name, sizeof (name), "%s/%s", com_gamedir, fname);
+		sl = name + 1;
+		while (*sl)
+		{
+			if (*sl == '/')
+			{
+				*sl = 0;
+				Sys_mkdir (name); // make sure each part of the path exists.
+				*sl = '/';
+			}
+			sl++;
+		}
+		file = fopen (name, "wb");
+		break;
+	default:
+		Con_Warning ("PF_fopen: unsupported mode: %i\n", fmode);
+		return;
+	}
+	if (!file)
+		return;
+
+	for (i = 0;; i++)
+	{
+		if (i == qcfiles_max)
+		{
+			qcfiles_max++;
+			qcfiles = Mem_Realloc (qcfiles, sizeof (*qcfiles) * qcfiles_max);
+		}
+		if (!qcfiles[i].file)
+			break;
+	}
+	qcfiles[i].filebase = ftell (file);
+	qcfiles[i].owningvm = qcvm;
+	qcfiles[i].file = file;
+	qcfiles[i].mode = fmode;
+	// reading needs size info
+	qcfiles[i].filesize = filesize;
+	// clear the read cache.
+	qcfiles[i].fileoffset = qcfiles[i].cacheoffset = qcfiles[i].cachesize = 0;
+
+	G_FLOAT (OFS_RETURN) = i + QC_FILE_BASE;
+}
+
+static void PF_fgets (void)
+{
+	size_t fileid = G_FLOAT (OFS_PARM0) - QC_FILE_BASE;
+	G_INT (OFS_RETURN) = 0;
+	if (fileid >= qcfiles_max)
+		Con_Warning ("PF_fgets: invalid file handle\n");
+	else if (!qcfiles[fileid].file)
+		Con_Warning ("PF_fgets: file not open\n");
+	else if (qcfiles[fileid].mode != 0)
+		Con_Warning ("PF_fgets: file not open for reading\n");
+	else
+	{
+		struct qcfile_s *f = &qcfiles[fileid];
+		char			*ret = PR_GetTempString ();
+		char			*s = ret;
+		char			*end = ret + STRINGTEMP_LENGTH;
+		for (;;)
+		{
+			if (f->cacheoffset == f->cachesize)
+			{
+				// figure out how much we can try to cache.
+				int sz = f->filesize - f->fileoffset;
+				if (sz < 0 || f->fileoffset < 0) //... maybe we shouldn't have implemented seek support.
+					sz = 0;
+				else if ((size_t)sz > sizeof (f->cache))
+					sz = sizeof (f->cache);
+				// read a chunk
+				f->cacheoffset = 0;
+				f->cachesize = fread (f->cache, 1, sz, f->file);
+				f->fileoffset += f->cachesize;
+				if (!f->cachesize)
+				{
+					if (s == ret)
+					{ // absolutely nothing to spew
+						G_INT (OFS_RETURN) = 0;
+						return;
+					}
+					// classic eof...
+					break;
+				}
+			}
+			*s = f->cache[f->cacheoffset++];
+			if (*s == '\n') // new line, yay!
+				break;
+			s++;
+			if (s == end)
+				s--; // rewind if we're overflowing, such that we truncate the string.
+		}
+		if (s > ret && s[-1] == '\r')
+			s--; // terminate it on the \r of a \r\n pair.
+		*s = 0;	 // terminate it
+		G_INT (OFS_RETURN) = PR_SetEngineString (ret);
+	}
+}
+
+static void PF_fputs (void)
+{
+	size_t		fileid = G_FLOAT (OFS_PARM0) - QC_FILE_BASE;
+	const char *str = PF_VarString (1);
+	if (fileid >= qcfiles_max)
+		Con_Warning ("PF_fputs: invalid file handle\n");
+	else if (!qcfiles[fileid].file)
+		Con_Warning ("PF_fputs: file not open\n");
+	else if (qcfiles[fileid].mode == 0)
+		Con_Warning ("PF_fgets: file not open for writing\n");
+	else
+		fputs (str, qcfiles[fileid].file);
+}
+
+static void PF_fclose (void)
+{
+	size_t fileid = G_FLOAT (OFS_PARM0) - QC_FILE_BASE;
+	if (fileid >= qcfiles_max)
+		Con_Warning ("PF_fclose: invalid file handle\n");
+	else if (!qcfiles[fileid].file)
+		Con_Warning ("PF_fclose: file not open\n");
+	else
+	{
+		fclose (qcfiles[fileid].file);
+		qcfiles[fileid].file = NULL;
+		qcfiles[fileid].owningvm = NULL;
+	}
+}
+
+static void PF_frikfile_shutdown (void)
+{
+	size_t i;
+	for (i = 0; i < qcfiles_max; i++)
+	{
+		if (qcfiles[i].owningvm == qcvm)
+		{
+			fclose (qcfiles[i].file);
+			qcfiles[i].file = NULL;
+			qcfiles[i].owningvm = NULL;
+		}
+	}
+}
+
+static void PF_fseek (void)
+{ // returns current position. or changes that position.
+	size_t fileid = G_FLOAT (OFS_PARM0) - QC_FILE_BASE;
+	G_INT (OFS_RETURN) = 0;
+	if (fileid >= qcfiles_max)
+		Con_Warning ("PF_fread: invalid file handle\n");
+	else if (!qcfiles[fileid].file)
+		Con_Warning ("PF_fread: file not open\n");
+	else
+	{
+		if (qcfiles[fileid].mode == 0)
+			G_INT (OFS_RETURN) = qcfiles[fileid].fileoffset; // when we're reading, use the cached read offset
+		else
+			G_INT (OFS_RETURN) = ftell (qcfiles[fileid].file) - qcfiles[fileid].filebase;
+		if (qcvm->argc > 1)
+		{
+			qcfiles[fileid].fileoffset = G_INT (OFS_PARM1);
+			fseek (qcfiles[fileid].file, qcfiles[fileid].filebase + qcfiles[fileid].fileoffset, SEEK_SET);
+			qcfiles[fileid].cachesize = qcfiles[fileid].cacheoffset = 0;
+		}
+	}
+}
+
 static void PF_whichpack (void)
 {
 	const char	*fname = G_STRING (OFS_PARM0); // uses native paths, as this isn't actually reading anything.
@@ -4142,6 +4386,7 @@ static struct svcustomstat_s *PR_CustomStat (int idx, int type)
 	sv.customstats[i].ptr = NULL;
 	return &sv.customstats[i];
 }
+
 static void PF_clientstat (void)
 {
 	int					   idx = G_FLOAT (OFS_PARM0);
@@ -4152,6 +4397,37 @@ static void PF_clientstat (void)
 		return;
 	stat->fld = fldofs;
 }
+
+static void PF_globalstat (void)
+{
+	int					   idx = G_FLOAT (OFS_PARM0);
+	int					   type = G_FLOAT (OFS_PARM1);
+	const char			  *globname = G_STRING (OFS_PARM2);
+	eval_t				  *ptr = PR_FindExtGlobal (type, globname);
+	struct svcustomstat_s *stat;
+	if (ptr)
+	{
+		stat = PR_CustomStat (idx, type);
+		if (!stat)
+			return;
+		stat->ptr = ptr;
+	}
+}
+
+static void PF_pointerstat (void)
+{
+	int					   idx = G_FLOAT (OFS_PARM0);
+	int					   type = G_FLOAT (OFS_PARM1);
+	int					   qcptr = G_INT (OFS_PARM2);
+	struct svcustomstat_s *stat;
+	if (qcptr < 0 || qcptr >= qcvm->max_edicts * qcvm->edict_size || (qcptr % qcvm->edict_size) < sizeof (edict_t) - sizeof (entvars_t))
+		return; // invalid pointer. this is a more strict check than the qcvm...
+	stat = PR_CustomStat (idx, type);
+	if (!stat)
+		return;
+	stat->ptr = (eval_t *)((byte *)qcvm->edicts + qcptr);
+}
+
 static void PF_isbackbuffered (void)
 {
 	unsigned int plnum = G_EDICTNUM (OFS_PARM0) - 1;
@@ -5106,6 +5382,11 @@ static struct
 	{"checkbuiltin",				PF_checkbuiltin,				PF_checkbuiltin,				0,		D("float(__variant funcref)", "Checks to see if the specified builtin is supported/mapped. This is intended as a way to check for #0 functions, allowing for simple single-builtin functions.")},
 	{"builtin_find",				PF_builtinsupported,			PF_builtinsupported,			100,	D("float(string builtinname)", "Looks to see if the named builtin is valid, and returns the builtin number it exists at.")},	// #100	//per builtin system.
 	{"anglemod",					PF_anglemod,					PF_anglemod,					102,	"float(float value)"},	//telejano
+	{"fopen",						PF_fopen,						PF_fopen,						110,	D("filestream(string filename, float mode, optional float mmapminsize)", "Opens a file, typically prefixed with \"data/\", for either read or write access.")},	// (FRIK_FILE)
+	{"fclose",						PF_fclose,						PF_fclose,						111,	"void(filestream fhandle)"},	// (FRIK_FILE)
+	{"fgets",						PF_fgets,						PF_fgets,						112,	D("string(filestream fhandle)", "Reads a single line out of the file. The new line character is not returned as part of the string. Returns the null string on EOF (use if not(string) to easily test for this, which distinguishes it from the empty string which is returned if the line being read is blank")},	// (FRIK_FILE)
+	{"fputs",						PF_fputs,						PF_fputs,						113,	D("void(filestream fhandle, string s, optional string s2, optional string s3, optional string s4, optional string s5, optional string s6, optional string s7)", "Writes the given string(s) into the file. For compatibility with fgets, you should ensure that the string is terminated with a \\n - this will not otherwise be done for you. It is up to the engine whether dos or unix line endings are actually written.")},	// (FRIK_FILE)
+	{"fseek",						PF_fseek,						PF_fseek,						0,		D("#define ftell fseek //c-compat\nint(filestream fhandle, optional int newoffset)", "Changes the current position of the file, if specified. Returns prior position, in bytes.")},
 	{"strlen",						PF_strlen,						PF_strlen,						114,	"float(string s)"},	// (FRIK_FILE)
 	{"strcat",						PF_strcat,						PF_strcat,						115,	"string(string s1, optional string s2, optional string s3, optional string s4, optional string s5, optional string s6, optional string s7, optional string s8)"},	// (FRIK_FILE)
 	{"substring",					PF_substring,					PF_substring,					116,	"string(string s, float start, float length)"},	// (FRIK_FILE)
@@ -5129,6 +5410,8 @@ static struct
 	{"strncasecmp",					PF_strncasecmp,					PF_strncasecmp,					230,	D("float(string s1, string s2, float len, optional float s1ofs, optional float s2ofs)", "Compares up to 'len' chars in the two strings without case sensitivity. s1ofs allows you to treat s2 as a substring to compare against, or should be 0.\nReturns 0 if they are equal. The sign of the return value may be significant, but should not be depended upon.")},
 	{"strtrim",						PF_strtrim,						PF_strtrim,						0,		D("string(string s)", "Trims the whitespace from the start+end of the string.")},
 	{"clientstat",					PF_clientstat,					PF_NoCSQC,						232,	D("void(float num, float type, .__variant fld)", "Specifies what data to use in order to send various stats, in a client-specific way.\n'num' should be a value between 32 and 127, other values are reserved.\n'type' must be set to one of the EV_* constants, one of EV_FLOAT, EV_STRING, EV_INTEGER, EV_ENTITY.\nfld must be a reference to the field used, each player will be sent only their own copy of these fields.")},	//EXT_CSQC
+	{"globalstat",					PF_globalstat,					PF_NoCSQC,						233,	D("void(float num, float type, string name)", "Specifies what data to use in order to send various stats, in a non-client-specific way. num and type are as in clientstat, name however, is the name of the global to read in the form of a string (pass \"foo\").")},	//EXT_CSQC_1 actually
+	{"pointerstat",					PF_pointerstat,					PF_NoCSQC,						0,		D("void(float num, float type, __variant *address)", "Specifies what data to use in order to send various stats, in a non-client-specific way. num and type are as in clientstat, address however, is the address of the variable you would like to use (pass &foo).")},
 	{"isbackbuffered",				PF_isbackbuffered,				PF_NoCSQC,						234,	D("float(entity player)", "Returns if the given player's network buffer will take multiple network frames in order to clear. If this builtin returns non-zero, you should delay or reduce the amount of reliable (and also unreliable) data that you are sending to that client.")},
 	{"te_bloodqw",					PF_sv_te_bloodqw,				NULL,							239,	"void(vector org, float count)"},
 	{"checkpvs",					PF_checkpvs,					PF_checkpvs,					240,	"float(vector viewpos, entity entity)"},
@@ -5410,6 +5693,7 @@ static struct
 #endif
 	{"DP_TE_STANDARDEFFECTBUILTINS"},
 	{"EXT_BITSHIFT"},
+	{"FRIK_FILE"},
 //	{"FTE_ENT_SKIN_CONTENTS"}, // SOLID_BSP&&skin==CONTENTS_FOO changes CONTENTS_SOLID to CONTENTS_FOO, allowing you to swim in moving ents without qc hacks,
 //							   // as well as correcting view cshifts etc.
 #ifdef PSET_SCRIPT
@@ -5613,6 +5897,7 @@ void PF_Fixme (void)
 void PR_ShutdownExtensions (void)
 {
 	PR_UnzoneAll ();
+	PF_frikfile_shutdown ();
 	PF_buf_shutdown ();
 	tokenize_flush ();
 	pr_ext_warned_particleeffectnum = 0;

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -69,8 +69,6 @@ typedef enum multicast_e
 } multicast_t;
 static void SV_Multicast (multicast_t to, float *org, int msg_entity, unsigned int requireext2);
 
-#define RETURN_EDICT(e) (((int *)qcvm->globals)[OFS_RETURN] = EDICT_TO_PROG (e))
-
 int PR_MakeTempString (const char *val)
 {
 	char *tmp = PR_GetTempString ();
@@ -4822,7 +4820,7 @@ static void PF_cl_drawfill (void)
 	vulkan_globals.vk_cmd_draw (cbx->cb, 6, 1, 0, 0);
 }
 
-void PF_cl_playerkey_internal (int player, const char *key, qboolean retfloat)
+static void PF_cl_playerkey_internal (int player, const char *key, qboolean retfloat)
 {
 	char		buf[1024];
 	const char *ret = buf;
@@ -4899,6 +4897,73 @@ static void PF_cl_registercommand (void)
 	const char *cmdname = G_STRING (OFS_PARM0);
 	Cmd_AddCommand (cmdname, NULL);
 }
+
+static void PF_cl_serverkey_internal (const char *key, qboolean retfloat)
+{
+	char		buf[1024];
+	const char *ret;
+	if (!strcmp (key, "constate"))
+	{
+		if (cls.state != ca_connected)
+			ret = "disconnected";
+		else if (cls.signon == SIGNONS)
+			ret = "active";
+		else
+			ret = "connecting";
+	}
+	else
+	{
+		ret = Info_GetKey (cl.serverinfo, key, buf, sizeof (buf));
+	}
+
+	if (retfloat)
+		G_FLOAT (OFS_RETURN) = atof (ret);
+	else
+		G_INT (OFS_RETURN) = PR_SetEngineString (ret);
+}
+
+static void PF_cl_serverkey_s (void)
+{
+	const char *keyname = G_STRING (OFS_PARM0);
+	PF_cl_serverkey_internal (keyname, false);
+}
+static void PF_cl_serverkey_f (void)
+{
+	const char *keyname = G_STRING (OFS_PARM0);
+	PF_cl_serverkey_internal (keyname, true);
+}
+
+static void PF_sv_serverkey_internal (const char *key, qboolean retfloat)
+{
+	char		buf[1024];
+	const char *ret = Info_GetKey (svs.serverinfo, key, buf, sizeof (buf));
+
+	if (retfloat)
+		G_FLOAT (OFS_RETURN) = atof (ret);
+	else
+		G_INT (OFS_RETURN) = PR_SetEngineString (ret);
+}
+
+static void PF_sv_serverkey_s (void)
+{
+	const char *keyname = G_STRING (OFS_PARM0);
+	PF_sv_serverkey_internal (keyname, false);
+}
+
+static void PF_sv_serverkey_f (void)
+{
+	const char *keyname = G_STRING (OFS_PARM0);
+	PF_sv_serverkey_internal (keyname, true);
+}
+
+static void PF_sv_forceinfokey (void)
+{
+	int			edict = G_EDICTNUM (OFS_PARM0);
+	const char *keyname = G_STRING (OFS_PARM1);
+	const char *value = G_STRING (OFS_PARM2);
+	SV_UpdateInfo (edict, keyname, value);
+}
+
 static void PF_cl_readbyte (void)
 {
 	G_FLOAT (OFS_RETURN) = MSG_ReadByte ();
@@ -5049,6 +5114,7 @@ static struct
 	{"strunzone",					PF_strunzone,					PF_strunzone,					119,	D("void(string s)", "Destroys a string that was allocated by strunzone. Further references to the string MAY crash the game.")},	// (FRIK_FILE)
 	{"tokenize_menuqc",				PF_Tokenize,					PF_Tokenize,					0,		"float(string s)"},
 	{"localsound",					PF_NoSSQC,						PF_cl_localsound,				177,	D("void(string soundname, optional float channel, optional float volume)", "Plays a sound... locally... probably best not to call this from ssqc. Also disables reverb.")},//	#177
+	{"forceinfokey",	            PF_sv_forceinfokey,	            PF_NoCSQC,			            213,	D("void(entity player, string key, string value)", "Directly changes a user's info without pinging off the client. Also allows explicitly setting * keys, including *spectator. Does not affect the user's config or other servers.")}, // #213
 	{"bitshift",					PF_bitshift,					PF_bitshift,					218,	"float(float number, float quantity)"},
 	{"te_lightningblood",			PF_sv_te_lightningblood,		NULL,							219,	"void(vector org)"},
 	{"strstrofs",					PF_strstrofs,					PF_strstrofs,					221,	D("float(string s1, string sub, optional float startidx)", "Returns the 0-based offset of sub within the s1 string, or -1 if sub is not in s1.\nIf startidx is set, this builtin will ignore matches before that 0-based offset.")},
@@ -5110,6 +5176,8 @@ static struct
 	{"getplayerkeyfloat",			PF_NoSSQC,						PF_cl_playerkey_f,				0,		D("float(float playernum, string keyname, optional float assumevalue)", "Cheaper version of getplayerkeyvalue that avoids the need for so many tempstrings.")},
 	{"registercommand",				PF_NoSSQC,						PF_cl_registercommand,			352,	D("void(string cmdname)", "Register the given console command, for easy console use.\nConsole commands that are later used will invoke CSQC_ConsoleCommand.")},//(EXT_CSQC)
 	{"wasfreed",					PF_WasFreed,					PF_WasFreed,					353,	D("float(entity ent)", "Quickly check to see if the entity is currently free. This function is only valid during the two-second non-reuse window, after that it may give bad results. Try one second to make it more robust.")},//(EXT_CSQC) (should be availabe on server too)
+	{"serverkey",					PF_sv_serverkey_s,				PF_cl_serverkey_s,				354,	D("string(string key)", "Look up a key in the server's public serverinfo string")},//
+	{"serverkeyfloat",				PF_sv_serverkey_f,				PF_cl_serverkey_f,				0,		D("float(string key, optional float assumevalue)", "Version of serverkey that returns the value as a float (which avoids tempstrings).")},//
 	{"readbyte",					PF_NoSSQC,						PF_cl_readbyte,					360,	"float()"},// (EXT_CSQC)
 	{"readchar",					PF_NoSSQC,						PF_cl_readchar,					361,	"float()"},// (EXT_CSQC)
 	{"readshort",					PF_NoSSQC,						PF_cl_readshort,				362,	"float()"},// (EXT_CSQC)
@@ -5354,6 +5422,7 @@ static struct
 	{"FTE_QC_CHECKCOMMAND"},
 	{"FTE_QC_CROSSPRODUCT"},
 	{"FTE_QC_INFOKEY"},
+	{"FTE_FORCEINFOKEY"},
 	{"FTE_QC_INTCONV"},
 	{"FTE_QC_MULTICAST"},
 	{"FTE_STRINGS"},

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -155,6 +155,8 @@ edict_t *PROG_TO_EDICT (int n);
 #define PROG_TO_EDICT(p) ((edict_t *)((byte *)qcvm->edicts + p))
 #endif
 
+#define RETURN_EDICT(e) (((int *)qcvm->globals)[OFS_RETURN] = EDICT_TO_PROG (e))
+
 #define G_FLOAT(o)	  (qcvm->globals[o])
 #define G_INT(o)	  (*(int *)&qcvm->globals[o])
 #define G_UINT(o)	  (*(unsigned int *)&qcvm->globals[o])

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // server.h
 
+#define SERVER_INFO_STRING_SIZE 8192
+
 typedef struct
 {
 	int				 maxclients;
@@ -32,6 +34,8 @@ typedef struct
 	struct client_s *clients;			 // [maxclients]
 	int				 serverflags;		 // episode completion information
 	qboolean		 changelevel_issued; // cleared when at SV_SpawnServer
+
+	char serverinfo[SERVER_INFO_STRING_SIZE]; // \key\value infostring data.
 } server_static_t;
 
 //=============================================================================
@@ -211,6 +215,8 @@ typedef struct client_s
 	int		 lastmovemessage;
 	double	 lastmovetime;
 	qboolean knowntoqc; // putclientinserver was called
+
+	char userinfo[SERVER_INFO_STRING_SIZE]; // spike -- for csqc to (ab)use.
 } client_t;
 
 //=============================================================================


### PR DESCRIPTION
In an attempt to make this mod :  https://crmod7.quakeone.com/ work, mentioned in https://github.com/Novum/vkQuake/issues/915. 

This covers the missing extensions of the `crmod7`.  We can now join a multiplayer game at: `denver.quakeone.com:26000` using the command line : `-game qssm -game crmod7` where:
-  `crmod7` : The mod https://github.com/quakeone/CRMod7 with the progs compiled from scratch
- `qssm` : From the package install found here : https://qssm.quakeone.com/ put its `id1` contents in the `qssm` folder.

TODO : Add map download ?

All that changes are borrowed from QSS. (of course)