### PR TITLE
Make all image formats (png tga jpg pcx) available for HUD drawing functions, Filesystem fixes and improvements

### DIFF
--- a/Quake/cfgfile.c
+++ b/Quake/cfgfile.c
@@ -152,9 +152,9 @@ void CFG_CloseConfig (void)
 
 int CFG_OpenConfig (const char *cfg_name)
 {
-	FILE	*f = NULL;
-	long	 length;
-	qboolean pak = false;
+	FILE	   *f = NULL;
+	qfilesize_t length;
+	qboolean	pak = false;
 
 	CFG_CloseConfig ();
 
@@ -166,13 +166,11 @@ int CFG_OpenConfig (const char *cfg_name)
 	}
 	if (f)
 	{
-		fseek (f, 0, SEEK_END);
-		length = ftell (f);
-		fseek (f, 0, SEEK_SET);
+		length = Sys_filelength (f);
 	}
 	else
 	{
-		length = (long)COM_FOpenFile (cfg_name, &f, NULL);
+		length = COM_FOpenFile (cfg_name, &f, NULL);
 		pak = file_from_pak;
 		if (length == -1)
 			return -1;
@@ -180,7 +178,7 @@ int CFG_OpenConfig (const char *cfg_name)
 
 	cfg_file = (fshandle_t *)Mem_Alloc (sizeof (fshandle_t));
 	cfg_file->file = f;
-	cfg_file->start = ftell (f);
+	cfg_file->start = Sys_ftell (f);
 	cfg_file->pos = 0;
 	cfg_file->length = length;
 	cfg_file->pak = pak;

--- a/Quake/cmd.c
+++ b/Quake/cmd.c
@@ -288,9 +288,8 @@ void Cmd_Exec_f (void)
 	qboolean read_from_pref_path = false;
 	if (f)
 	{
-		fseek (f, 0, SEEK_END);
-		long length = ftell (f);
-		fseek (f, 0, SEEK_SET);
+		qfilesize_t length = Sys_filelength (f);
+
 		buf = Mem_Alloc (length + 1);
 		if (fread (buf, 1, length, f) != length)
 			Mem_Free (buf);

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1818,7 +1818,7 @@ QUAKE FILESYSTEM
 =============================================================================
 */
 
-THREAD_LOCAL qfileofs_t com_filesize;
+THREAD_LOCAL qfilesize_t com_filesize;
 
 //
 // on-disk pakfile
@@ -1921,7 +1921,7 @@ void COM_CreatePath (char *path)
 COM_filelength
 ================
 */
-qfileofs_t COM_filelength (FILE *f)
+static qfilesize_t COM_filelength (FILE *f)
 {
 	return Sys_filelength (f);
 }
@@ -1936,7 +1936,7 @@ If neither of file or handle is set, this
 can be used for detecting a file's presence.
 ===========
 */
-static int COM_FindFile (const char *filename, int *handle, FILE **file, unsigned int *path_id)
+static qfilesize_t COM_FindFile (const char *filename, int *handle, FILE **file, unsigned int *path_id)
 {
 	searchpath_t *search;
 	char		  netpath[MAX_OSPATH];
@@ -1968,15 +1968,18 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file, unsigne
 					*path_id = search->path_id;
 				if (handle)
 				{
-					*handle = pak->handle;
-					Sys_FileSeek (pak->handle, pak->files[i].filepos);
+					// We can have concurrent reads to the pack (either as file or memory-based)
+					// So we MUST duplicate the pak handle to allow independent reads and seeks.
+					int new_handle = Sys_DuplicateHandle (pak->handle);
+					Sys_FileSeek (new_handle, pak->files[i].filepos);
+					*handle = new_handle;
 					return com_filesize;
 				}
 				else if (file)
 				{ /* open a new file on the pakfile */
 					*file = fopen (pak->filename, "rb");
 					if (*file)
-						fseek (*file, pak->files[i].filepos, SEEK_SET);
+						Sys_fseek (*file, pak->files[i].filepos, SEEK_SET);
 					return com_filesize;
 				}
 				else /* for COM_FileExists() */
@@ -2050,7 +2053,7 @@ Returns whether the file is found in the quake filesystem.
 */
 qboolean COM_FileExists (const char *filename, unsigned int *path_id)
 {
-	int ret = COM_FindFile (filename, NULL, NULL, path_id);
+	qfilesize_t ret = COM_FindFile (filename, NULL, NULL, path_id);
 	return (ret == -1) ? false : true;
 }
 
@@ -2063,7 +2066,7 @@ returns a handle and a length
 it may actually be inside a pak file
 ===========
 */
-int COM_OpenFile (const char *filename, int *handle, unsigned int *path_id)
+qfilesize_t COM_OpenFile (const char *filename, int *handle, unsigned int *path_id)
 {
 	return COM_FindFile (filename, handle, NULL, path_id);
 }
@@ -2076,7 +2079,7 @@ If the requested file is inside a packfile, a new FILE * will be opened
 into the file.
 ===========
 */
-int COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id)
+qfilesize_t COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id)
 {
 	return COM_FindFile (filename, NULL, file, path_id);
 }
@@ -2112,9 +2115,9 @@ Allways appends a 0 byte.
 */
 byte *COM_LoadFile (const char *path, unsigned int *path_id)
 {
-	int	  h;
-	byte *buf;
-	int	  len;
+	int			h;
+	byte	   *buf;
+	qfilesize_t len;
 
 	buf = NULL; // quiet compiler warning
 
@@ -2138,9 +2141,9 @@ byte *COM_LoadFile (const char *path, unsigned int *path_id)
 
 byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 {
-	FILE *f;
-	byte *data;
-	long  len, actuallen;
+	FILE	   *f;
+	byte	   *data;
+	qfilesize_t len, actuallen;
 
 	// ericw -- this is used by Host_Loadgame_f. Translate CRLF to LF on load games,
 	// othewise multiline messages have a garbage character at the end of each line.
@@ -2715,9 +2718,9 @@ void COM_InitFilesystem (void) // johnfitz -- modified based on topaz's tutorial
 
 size_t FS_fread (void *ptr, size_t size, size_t nmemb, fshandle_t *fh)
 {
-	long   byte_size;
-	long   bytes_read;
-	size_t nmemb_read;
+	qfilesize_t byte_size;
+	qfilesize_t bytes_read;
+	qfilesize_t nmemb_read;
 
 	if (!fh)
 	{
@@ -2752,10 +2755,8 @@ size_t FS_fread (void *ptr, size_t size, size_t nmemb, fshandle_t *fh)
 	return nmemb_read;
 }
 
-int FS_fseek (fshandle_t *fh, long offset, int whence)
+int FS_fseek (fshandle_t *fh, qfileofs_t offset, int whence)
 {
-	/* I don't care about 64 bit off_t or fseeko() here.
-	 * the quake/hexen2 file system is 32 bits, anyway. */
 	int ret;
 
 	if (!fh)
@@ -2790,7 +2791,7 @@ int FS_fseek (fshandle_t *fh, long offset, int whence)
 	if (offset > fh->length) /* just seek to end */
 		offset = fh->length;
 
-	ret = fseek (fh->file, fh->start + offset, SEEK_SET);
+	ret = Sys_fseek (fh->file, fh->start + offset, SEEK_SET);
 	if (ret < 0)
 		return ret;
 
@@ -2808,7 +2809,7 @@ int FS_fclose (fshandle_t *fh)
 	return fclose (fh->file);
 }
 
-long FS_ftell (fshandle_t *fh)
+qfileofs_t FS_ftell (fshandle_t *fh)
 {
 	if (!fh)
 	{
@@ -2823,7 +2824,7 @@ void FS_rewind (fshandle_t *fh)
 	if (!fh)
 		return;
 	clearerr (fh->file);
-	fseek (fh->file, fh->start, SEEK_SET);
+	Sys_fseek (fh->file, fh->start, SEEK_SET);
 	fh->pos = 0;
 }
 
@@ -2873,12 +2874,12 @@ char *FS_fgets (char *s, int size, fshandle_t *fh)
 		size = (fh->length - fh->pos) + 1;
 
 	ret = fgets (s, size, fh->file);
-	fh->pos = ftell (fh->file) - fh->start;
+	fh->pos = Sys_ftell (fh->file) - fh->start;
 
 	return ret;
 }
 
-long FS_filelength (fshandle_t *fh)
+qfilesize_t FS_filelength (fshandle_t *fh)
 {
 	if (!fh)
 	{

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -387,11 +387,11 @@ const char *COM_GetGameNames (qboolean full);
 qboolean	COM_GameDirMatches (const char *tdirs);
 qboolean	COM_ModForbiddenChars (const char *p);
 
-void	 COM_WriteFile (const char *filename, const void *data, int len);
-int		 COM_OpenFile (const char *filename, int *handle, unsigned int *path_id);
-int		 COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id);
-qboolean COM_FileExists (const char *filename, unsigned int *path_id);
-void	 COM_CloseFile (int h);
+void		COM_WriteFile (const char *filename, const void *data, int len);
+qfilesize_t COM_OpenFile (const char *filename, int *handle, unsigned int *path_id);
+qfilesize_t COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id);
+qboolean	COM_FileExists (const char *filename, unsigned int *path_id);
+void		COM_CloseFile (int h);
 
 byte *COM_LoadFile (const char *path, unsigned int *path_id);
 
@@ -440,23 +440,25 @@ size_t COM_SanitizeDescriptionString (char *dst, size_t dstsize, const char *src
 
 typedef struct _fshandle_t
 {
-	FILE	*file;
-	qboolean pak;	 /* is the file read from a pak */
-	long	 start;	 /* file or data start position */
-	long	 length; /* file or data size */
-	long	 pos;	 /* current position relative to start */
+	FILE	   *file;
+	qboolean	pak;	/* is the file read from a pak */
+	qfileofs_t	start;	/* file or data start position */
+	qfilesize_t length; /* file or data size */
+	qfileofs_t	pos;	/* current position relative to start */
 } fshandle_t;
 
+// Only read 2**31 elements max, should be enough still
 size_t FS_fread (void *ptr, size_t size, size_t nmemb, fshandle_t *fh);
-int	   FS_fseek (fshandle_t *fh, long offset, int whence);
-long   FS_ftell (fshandle_t *fh);
-void   FS_rewind (fshandle_t *fh);
-int	   FS_feof (fshandle_t *fh);
-int	   FS_ferror (fshandle_t *fh);
-int	   FS_fclose (fshandle_t *fh);
-int	   FS_fgetc (fshandle_t *fh);
-char  *FS_fgets (char *s, int size, fshandle_t *fh);
-long   FS_filelength (fshandle_t *fh);
+
+int			FS_fseek (fshandle_t *fh, qfileofs_t offset, int whence);
+qfileofs_t	FS_ftell (fshandle_t *fh);
+void		FS_rewind (fshandle_t *fh);
+int			FS_feof (fshandle_t *fh);
+int			FS_ferror (fshandle_t *fh);
+int			FS_fclose (fshandle_t *fh);
+int			FS_fgetc (fshandle_t *fh);
+char	   *FS_fgets (char *s, int size, fshandle_t *fh);
+qfilesize_t FS_filelength (fshandle_t *fh);
 
 extern struct cvar_s registered;
 extern qboolean		 standard_quake, rogue, hipnotic;

--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -92,11 +92,13 @@ typedef struct cachepic_s
 	byte   padding[32]; // for appended glpic
 } cachepic_t;
 
-#define MAX_CACHED_PICS 512 // Spike -- increased to avoid csqc issues.
-cachepic_t menu_cachepics[MAX_CACHED_PICS];
-int		   menu_numcachepics;
+// TODO : vso : should be dynamically allocated instead ?
+// On the other hand it takes so little memory that we can push MAX_CACHED_PICS very very high and never touch it again.
+#define MAX_CACHED_PICS 8192 // vso : from Spike = 512 - increased to avoid csqc issues.
+static cachepic_t menu_cachepics[MAX_CACHED_PICS];
+static int		  menu_numcachepics;
 
-byte menuplyr_pixels[4096];
+static byte menuplyr_pixels[4096];
 
 //  scrap allocation
 //  Allocate all the little status bar obejcts into a single texture
@@ -197,7 +199,7 @@ qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags)
 	// Spike -- added cachepic stuff here, to avoid glitches if the function is called multiple times with the same image.
 	for (pic = menu_cachepics, i = 0; i < menu_numcachepics; pic++, i++)
 	{
-		if (!strcmp (name, pic->name))
+		if (!strncmp (name, pic->name, countof (pic->name)))
 			return &pic->pic;
 	}
 	if (menu_numcachepics == MAX_CACHED_PICS)
@@ -206,7 +208,7 @@ qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags)
 	p = (qpic_t *)W_GetLumpName (name, &info);
 	if (!p)
 	{
-		Con_SafePrintf ("W_GetLumpName: %s not found\n", name);
+		Con_DPrintf ("W_GetLumpName: %s not found\n", name);
 		return pic_nul; // johnfitz
 	}
 	if (info->type != TYP_QPIC)
@@ -254,9 +256,9 @@ qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags)
 	}
 
 	menu_numcachepics++;
-	strcpy (pic->name, name);
+	q_strlcpy (pic->name, name, countof (pic->name));
 	pic->pic = *p;
-	memcpy (pic->pic.data, &gl, sizeof (glpic_t));
+	memcpy ((void *)&(pic->pic.data), &gl, sizeof (glpic_t));
 
 	return &pic->pic;
 }
@@ -288,12 +290,11 @@ qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
 {
 	cachepic_t *pic;
 	int			i;
-	qpic_t	   *dat;
 	glpic_t		gl;
 
 	for (pic = menu_cachepics, i = 0; i < menu_numcachepics; pic++, i++)
 	{
-		if (!strcmp (path, pic->name))
+		if (!strncmp (path, pic->name, countof (pic->name)))
 			return &pic->pic;
 	}
 	if (menu_numcachepics == MAX_CACHED_PICS)
@@ -302,33 +303,44 @@ qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
 	//
 	// load the pic from disk
 	//
-	dat = (qpic_t *)COM_LoadFile (path, NULL);
-	if (!dat)
+	unsigned int   pic_width = 0;
+	unsigned int   pic_height = 0;
+	void		  *pic_data = NULL;
+	//
+	enum srcformat pic_fmt = SRC_INDEXED;
+
+	// Image_LoadImage works without file extension.
+	char npath[MAX_QPATH];
+	COM_StripExtension (path, npath, sizeof (npath));
+
+	pic_data = Image_LoadImage (npath, (int *)&pic_width, (int *)&pic_height, &pic_fmt, 0);
+
+	if (!pic_data)
 		return NULL;
-	SwapPic (dat);
 
 	menu_numcachepics++;
-	strcpy (pic->name, path);
+	q_strlcpy (pic->name, path, countof (pic->name));
 
 	// HACK HACK HACK --- we need to keep the bytes for
 	// the translatable player picture just for the menu
 	// configuration dialog
-	if (!strcmp (path, "gfx/menuplyr.lmp"))
-		memcpy (menuplyr_pixels, dat->data, dat->width * dat->height);
+	if (!strcmp (npath, "gfx/menuplyr.lmp"))
+		memcpy (menuplyr_pixels, pic_data, pic_width * pic_height);
 
-	pic->pic.width = dat->width;
-	pic->pic.height = dat->height;
+	pic->pic.width = pic_width;
+	pic->pic.height = pic_height;
 
-	gl.gltexture = TexMgr_LoadImage (
-		NULL, path, dat->width, dat->height, SRC_INDEXED, dat->data, path, sizeof (int) * 2, texflags | TEXPREF_NOPICMIP); // johnfitz -- TexMgr
+	gl.gltexture = TexMgr_LoadImage (NULL, path, pic_width, pic_height, pic_fmt, pic_data, path, 0, texflags | TEXPREF_NOPICMIP); // johnfitz -- TexMgr
+
+	// those are always normalized coordinates
 	gl.sl = 0;
 	gl.sh = 1;
 	gl.tl = 0;
 	gl.th = 1;
 
-	memcpy (pic->pic.data, &gl, sizeof (glpic_t));
+	memcpy ((void *)&(pic->pic.data), &gl, sizeof (glpic_t));
 
-	Mem_Free (dat);
+	Mem_Free (pic_data);
 
 	return &pic->pic;
 }
@@ -361,7 +373,8 @@ static qpic_t *Draw_MakePic (const char *name, int width, int height, const byte
 	gl.sh = 1;
 	gl.tl = 0;
 	gl.th = 1;
-	memcpy (pic->data, &gl, sizeof (glpic_t));
+
+	memcpy ((void *)&(pic->data), &gl, sizeof (glpic_t));
 
 	return pic;
 }

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1370,7 +1370,7 @@ static void Mod_LoadLighting (qmodel_t *mod, byte *mod_base, lump_t *l)
 					Mem_Free (data);
 					return;
 				}
-				Con_Printf ("Outdated .lit file (%s should be %u bytes, not %" SDL_PRIs64 ")\n", litfilename, 8 + l->filelen * 3, com_filesize);
+				Con_Printf ("Outdated .lit file (%s should be %u bytes, not %lld)\n", litfilename, 8 + l->filelen * 3, com_filesize);
 			}
 			else
 			{
@@ -2826,7 +2826,7 @@ static FILE *Mod_FindVisibilityExternal (qmodel_t *mod, const char *loadname)
 		if (!q_strcasecmp (header.mapname, shortname))
 			break;
 		pos += header.filelen + VISPATCH_HEADER_LEN;
-		fseek (f, pos, SEEK_SET);
+		Sys_fseek (f, pos, SEEK_SET);
 	}
 	if (r != VISPATCH_HEADER_LEN)
 	{

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1486,7 +1486,7 @@ void TexMgr_ReloadImage (gltexture_t *glt, int shirt, int pants)
 		COM_FOpenFile (glt->source_file, &f, NULL);
 		if (!f)
 			goto invalid;
-		fseek (f, glt->source_offset, SEEK_CUR);
+		Sys_fseek (f, glt->source_offset, SEEK_CUR);
 		size = glt->source_width * glt->source_height;
 		/* should be SRC_INDEXED, but no harm being paranoid:  */
 		if (glt->source_format == SRC_RGBA)

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -4117,8 +4117,10 @@ void VID_Shutdown (void)
 {
 	if (vid_initialized)
 	{
-		SDL_QuitSubSystem (SDL_INIT_VIDEO);
+		assert (draw_context != NULL);
+		SDL_DestroyWindow (draw_context);
 		draw_context = NULL;
+		SDL_QuitSubSystem (SDL_INIT_VIDEO);
 		PL_VID_Shutdown ();
 	}
 }

--- a/Quake/image.c
+++ b/Quake/image.c
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
-static byte *Image_LoadPCX (FILE *f, int *width, int *height);
-static byte *Image_LoadLMP (FILE *f, int *width, int *height);
+static byte *Image_LoadPCX (int file_handle, int *width, int *height, const char *image_name);
+static byte *Image_LoadLMP (int file_handle, int *width, int *height, const char *image_name);
 
 #ifdef _MSC_VER
 // Disable warning C4505: Unused functions
@@ -48,6 +48,7 @@ static byte *Image_LoadLMP (FILE *f, int *width, int *height);
 #define STBI_NO_PIC
 #define STBI_NO_PNM
 #define STBI_NO_LINEAR
+#define STBI_NO_STDIO
 // plug our Mem_Alloc in stb_image:
 #define STBI_MALLOC(sz)		   Mem_Alloc (sz)
 #define STBI_REALLOC(p, newsz) Mem_Realloc (p, newsz)
@@ -96,40 +97,35 @@ void lodepng_free (void *ptr)
 	Mem_Free (ptr);
 }
 
-static THREAD_LOCAL char loadfilename[MAX_OSPATH]; // file scope so that error messages can use it
-
-typedef struct stdio_buffer_s
+static int stbi_read_cb (void *user, char *data, int size)
 {
-	FILE		 *f;
-	unsigned char buffer[1024];
-	int			  size;
-	int			  pos;
-} stdio_buffer_t;
+	int *file_handle = (int *)user;
 
-static stdio_buffer_t *Buf_Alloc (FILE *f)
-{
-	stdio_buffer_t *buf = (stdio_buffer_t *)Mem_Alloc (sizeof (stdio_buffer_t));
-	buf->f = f;
-	return buf;
+	return Sys_FileRead (*file_handle, (void *)data, size);
 }
 
-static void Buf_Free (stdio_buffer_t *buf)
+static void stbi_skip_cb (void *user, int n)
 {
-	Mem_Free (buf);
-}
+	int *file_handle = (int *)user;
 
-static inline int Buf_GetC (stdio_buffer_t *buf)
-{
-	if (buf->pos >= buf->size)
+	qfileofs_t current_pos = Sys_FilePos (*file_handle);
+
+	qfileofs_t new_pos = current_pos + n;
+
+	// mimic default stbi__stdio_skip() :
+	Sys_FileSeek (*file_handle, new_pos);
+
+	if (Sys_fgetc (*file_handle) != EOF)
 	{
-		buf->size = fread (buf->buffer, 1, sizeof (buf->buffer), buf->f);
-		buf->pos = 0;
-
-		if (buf->size == 0)
-			return EOF;
+		Sys_FileSeek (*file_handle, new_pos);
 	}
+}
 
-	return buf->buffer[buf->pos++];
+static int stbi_eof_cb (void *user)
+{
+	int *file_handle = (int *)user;
+
+	return (int)Sys_feof (*file_handle);
 }
 
 /*
@@ -147,22 +143,26 @@ byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat
 {
 	static const char *const stbi_formats[] = {"png", "tga", "jpg", NULL};
 
-	FILE *f;
-	int	  i;
+	char loadfilename[MAX_OSPATH];
+
+	int file_handle = -1;
+	int i;
 
 	unsigned int opened_file_path_id = 0;
 
 	for (i = 0; stbi_formats[i]; i++)
 	{
 		q_snprintf (loadfilename, sizeof (loadfilename), "%s.%s", name, stbi_formats[i]);
-		COM_FOpenFile (loadfilename, &f, &opened_file_path_id);
+		COM_OpenFile (loadfilename, &file_handle, &opened_file_path_id);
 
-		if (f)
+		if (file_handle >= 0)
 		{
 			if (opened_file_path_id >= min_path_id)
 			{
+				stbi_io_callbacks sys_file_cb = {.read = stbi_read_cb, .eof = stbi_eof_cb, .skip = stbi_skip_cb};
+
 				// data is managed by our Mem_Alloc routines, nothing more to do.
-				byte *data = stbi_load_from_file (f, width, height, NULL, 4);
+				byte *data = stbi_load_from_callbacks (&sys_file_cb, (void *)&file_handle, width, height, NULL, 4);
 
 				if (data)
 				{
@@ -170,46 +170,47 @@ byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat
 				}
 				else
 					Con_Warning ("couldn't load %s (%s)\n", loadfilename, stbi_failure_reason ());
-				fclose (f);
+
+				COM_CloseFile (file_handle);
 				return data;
 			}
 			else
 			{
 				Con_DPrintf ("Image_LoadImage: ignored %s from a gamedir with lower priority\n", loadfilename);
-				fclose (f);
+				COM_CloseFile (file_handle);
 			}
 		}
 	}
 
 	q_snprintf (loadfilename, sizeof (loadfilename), "%s.pcx", name);
-	COM_FOpenFile (loadfilename, &f, &opened_file_path_id);
-	if (f)
+	COM_OpenFile (loadfilename, &file_handle, &opened_file_path_id);
+	if (file_handle >= 0)
 	{
 		if (opened_file_path_id >= min_path_id)
 		{
 			*fmt = SRC_RGBA;
-			return Image_LoadPCX (f, width, height);
+			return Image_LoadPCX (file_handle, width, height, loadfilename);
 		}
 		else
 		{
 			Con_DPrintf ("Image_LoadImage: ignored %s from a gamedir with lower priority\n", loadfilename);
-			fclose (f);
+			COM_CloseFile (file_handle);
 		}
 	}
 
 	q_snprintf (loadfilename, sizeof (loadfilename), "%s%s.lmp", "", name);
-	COM_FOpenFile (loadfilename, &f, &opened_file_path_id);
-	if (f)
+	COM_OpenFile (loadfilename, &file_handle, &opened_file_path_id);
+	if (file_handle >= 0)
 	{
 		if (opened_file_path_id >= min_path_id)
 		{
 			*fmt = SRC_INDEXED;
-			return Image_LoadLMP (f, width, height);
+			return Image_LoadLMP (file_handle, width, height, loadfilename);
 		}
 		else
 		{
 			Con_DPrintf ("Image_LoadImage: ignored %s from a gamedir with lower priority\n", loadfilename);
-			fclose (f);
+			COM_CloseFile (file_handle);
 		}
 	}
 
@@ -297,18 +298,22 @@ typedef struct
 Image_LoadPCX
 ============
 */
-static byte *Image_LoadPCX (FILE *f, int *width, int *height)
+static byte *Image_LoadPCX (int file_handle, int *width, int *height, const char *image_name)
 {
-	pcxheader_t		pcx;
-	int				x, y, w, h, readbyte, runlength, start;
-	byte		   *p, *data;
-	byte			palette[768];
-	stdio_buffer_t *buf;
+	pcxheader_t pcx;
+	int			x, y, w, h, readbyte, runlength;
+	byte	   *p, *data;
+	byte		palette[768];
 
-	start = ftell (f); // save start of file (since we might be inside a pak file, SEEK_SET might not be the start of the pcx)
+	// save start of file since we might be inside a pak file
+	const int start = Sys_FilePos (file_handle);
 
-	if (fread (&pcx, sizeof (pcx), 1, f) != 1)
-		Sys_Error ("'%s' is not a valid PCX file", loadfilename);
+	// We may are in a pak file (in this case file_handle is the one of the pak),
+	// so that resource size is com_filesize
+	const int file_size = com_filesize;
+
+	if (Sys_FileRead (file_handle, &pcx, sizeof (pcx)) != sizeof (pcx))
+		Sys_Error ("'%s' is not a valid PCX file", image_name);
 
 	pcx.xmin = (unsigned short)LittleShort (pcx.xmin);
 	pcx.ymin = (unsigned short)LittleShort (pcx.ymin);
@@ -317,13 +322,13 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 	pcx.bytes_per_line = (unsigned short)LittleShort (pcx.bytes_per_line);
 
 	if (pcx.signature != 0x0A)
-		Sys_Error ("'%s' is not a valid PCX file", loadfilename);
+		Sys_Error ("'%s' is not a valid PCX file", image_name);
 
 	if (pcx.version != 5)
-		Sys_Error ("'%s' is version %i, should be 5", loadfilename, pcx.version);
+		Sys_Error ("'%s' is version %i, should be 5", image_name, pcx.version);
 
 	if (pcx.encoding != 1 || pcx.bits_per_pixel != 8 || pcx.color_planes != 1)
-		Sys_Error ("'%s' has wrong encoding or bit depth", loadfilename);
+		Sys_Error ("'%s' has wrong encoding or bit depth", image_name);
 
 	w = pcx.xmax - pcx.xmin + 1;
 	h = pcx.ymax - pcx.ymin + 1;
@@ -331,14 +336,13 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 	data = (byte *)Mem_Alloc ((w * h + 1) * 4); //+1 to allow reading padding byte on last line
 
 	// load palette
-	fseek (f, start + com_filesize - 768, SEEK_SET);
-	if (fread (palette, 1, 768, f) != 768)
-		Sys_Error ("'%s' is not a valid PCX file", loadfilename);
+	Sys_FileSeek (file_handle, start + file_size - 768);
+
+	if (Sys_FileRead (file_handle, palette, 768) != 768)
+		Sys_Error ("'%s' is not a valid PCX file", image_name);
 
 	// back to start of image data
-	fseek (f, start + sizeof (pcx), SEEK_SET);
-
-	buf = Buf_Alloc (f);
+	Sys_FileSeek (file_handle, start + sizeof (pcx));
 
 	for (y = 0; y < h; y++)
 	{
@@ -346,12 +350,12 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 
 		for (x = 0; x < (pcx.bytes_per_line);) // read the extra padding byte if necessary
 		{
-			readbyte = Buf_GetC (buf);
+			readbyte = Sys_fgetc (file_handle);
 
 			if (readbyte >= 0xC0)
 			{
 				runlength = readbyte & 0x3F;
-				readbyte = Buf_GetC (buf);
+				readbyte = Sys_fgetc (file_handle);
 			}
 			else
 				runlength = 1;
@@ -368,8 +372,7 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 		}
 	}
 
-	Buf_Free (buf);
-	fclose (f);
+	COM_CloseFile (file_handle);
 
 	*width = w;
 	*height = h;
@@ -392,30 +395,36 @@ typedef struct
 Image_LoadLMP
 ============
 */
-static byte *Image_LoadLMP (FILE *f, int *width, int *height)
+static byte *Image_LoadLMP (int file_handle, int *width, int *height, const char *image_name)
 {
 	lmpheader_t qpic;
 	size_t		pix;
 	void	   *data;
 
-	if (fread (&qpic, 1, sizeof (qpic), f) != sizeof (qpic))
-		Sys_Error ("'%s' is not a valid LMP file", loadfilename);
+	// We may are in a pak file (in this case file_handle is the one f the pak),
+	// so that resource size is com_filesize
+	const int file_size = com_filesize;
+
+	if (Sys_FileRead (file_handle, &qpic, sizeof (qpic)) != sizeof (qpic))
+		Sys_Error ("'%s' is not a valid LMP file", image_name);
 
 	qpic.width = LittleLong (qpic.width);
 	qpic.height = LittleLong (qpic.height);
 
 	pix = qpic.width * qpic.height;
 
-	if (com_filesize != 8 + pix)
+	if (file_size != 8 + pix)
 	{
-		fclose (f);
+		COM_CloseFile (file_handle);
 		return NULL;
 	}
 
 	data = (byte *)Mem_Alloc (pix); //+1 to allow reading padding byte on last line
-	if (fread (data, 1, pix, f) != pix)
-		Sys_Error ("'%s' is not a valid LMP file", loadfilename);
-	fclose (f);
+
+	if (Sys_FileRead (file_handle, data, pix) != pix)
+		Sys_Error ("'%s' is not a valid LMP file", image_name);
+
+	COM_CloseFile (file_handle);
 
 	*width = qpic.width;
 	*height = qpic.height;

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -51,6 +51,8 @@ extern cvar_t sv_gameplayfix_setmodelrealbox, r_fteparticles;
 cvar_t pr_checkextension = {"pr_checkextension", "1", CVAR_NONE}; // spike - enables qc extensions. if 0 then they're ALL BLOCKED! MWAHAHAHA! *cough* *splutter*
 static int pr_ext_warned_particleeffectnum;						  // so these only spam once per map
 
+extern qpic_t *pic_nul;
+
 static void *PR_FindExtGlobal (int type, const char *name);
 void		 SV_CheckVelocity (edict_t *ent);
 
@@ -3066,9 +3068,9 @@ static void PF_fopen (void)
 	switch (fmode)
 	{
 	case 0: // read
-		filesize = COM_FOpenFile (fname, &file, NULL);
+		filesize = (int)COM_FOpenFile (fname, &file, NULL);
 		if (!file && fallback)
-			filesize = COM_FOpenFile (fallback, &file, NULL);
+			filesize = (int)COM_FOpenFile (fallback, &file, NULL);
 		break;
 	case 1: // append
 		q_snprintf (name, sizeof (name), "%s/%s", com_gamedir, fname);
@@ -4745,7 +4747,8 @@ static struct
 }			 *qcpics;
 static size_t numqcpics;
 static size_t maxqcpics;
-void		  PR_ReloadPics (qboolean purge)
+
+void PR_ReloadPics (qboolean purge)
 {
 	numqcpics = 0;
 
@@ -4753,28 +4756,44 @@ void		  PR_ReloadPics (qboolean purge)
 	qcpics = NULL;
 	maxqcpics = 0;
 }
+
 #define PICFLAG_AUTO   0		 // value used when no flags known
 #define PICFLAG_WAD	   (1u << 0) // name matches that of a wad lump
 #define PICFLAG_WRAP   (1u << 2) // make sure npot stuff doesn't break wrapping.
 #define PICFLAG_MIPMAP (1u << 3) // disable use of scrap...
 #define PICFLAG_BLOCK  (1u << 9) // wait until the texture is fully loaded.
 #define PICFLAG_NOLOAD (1u << 31)
+
 static qpic_t *DrawQC_CachePic (const char *picname, unsigned int flags)
-{ // okay, so this is silly. we've ended up with 3 different cache levels. qcpics, pics, and images.
+{
+	if (strlen (picname) >= MAX_QPATH)
+		return NULL; // too long. get lost.
+
+	// okay, so this is silly. we've ended up with 3 different cache levels. qcpics, pics, and images.
 	size_t		 i;
 	unsigned int texflags;
+
+	// cleanup picname of all its leading slashes or backslashes
+	// because sometimes the input is silly.
+	char tmp_qpic_name[countof (qcpics[i].name)] = {0};
+
+	q_strlcpy (tmp_qpic_name, picname, countof (qcpics[i].name));
+
+	char *clean_picname = &tmp_qpic_name[0];
+
+	// trim leading:
+	while (*clean_picname == '/' || *clean_picname == '\\')
+		clean_picname++;
+
 	for (i = 0; i < numqcpics; i++)
-	{ // binary search? something more sane?
-		if (!strcmp (picname, qcpics[i].name))
+	{
+		// binary search? something more sane?
+		if (!strcmp (clean_picname, qcpics[i].name))
 		{
 			if (qcpics[i].pic)
 				return qcpics[i].pic;
-			break;
 		}
 	}
-
-	if (strlen (picname) >= MAX_QPATH)
-		return NULL; // too long. get lost.
 
 	if (flags & PICFLAG_NOLOAD)
 		return NULL; // its a query, not actually needed.
@@ -4785,7 +4804,8 @@ static qpic_t *DrawQC_CachePic (const char *picname, unsigned int flags)
 		qcpics = Mem_Realloc (qcpics, maxqcpics * sizeof (*qcpics));
 	}
 
-	strcpy (qcpics[i].name, picname);
+	strcpy (qcpics[i].name, clean_picname);
+
 	qcpics[i].flags = flags;
 	qcpics[i].pic = NULL;
 
@@ -4800,13 +4820,13 @@ static qpic_t *DrawQC_CachePic (const char *picname, unsigned int flags)
 	// the extra gfx/ crap is because DP insists on it for wad images. and its a nightmare to get things working in all engines if we don't accept that quirk
 	// too.
 	if (flags & PICFLAG_WAD)
-		qcpics[i].pic = Draw_PicFromWad2 (picname + (strncmp (picname, "gfx/", 4) ? 0 : 4), texflags);
-	else if (!strncmp (picname, "gfx/", 4) && !strchr (picname + 4, '.'))
-		qcpics[i].pic = Draw_PicFromWad2 (picname + 4, texflags);
+		qcpics[i].pic = Draw_PicFromWad2 (clean_picname + (strncmp (clean_picname, "gfx/", 4) ? 0 : 4), texflags);
+	else if (!strncmp (clean_picname, "gfx/", 4) && !strchr (clean_picname + 4, '.'))
+		qcpics[i].pic = Draw_PicFromWad2 (clean_picname + 4, texflags);
 
 	// okay, not a wad pic, try and load a lmp/tga/etc
-	if (!qcpics[i].pic)
-		qcpics[i].pic = Draw_TryCachePic (picname, texflags);
+	if (!qcpics[i].pic || qcpics[i].pic == pic_nul)
+		qcpics[i].pic = Draw_TryCachePic (clean_picname, texflags);
 
 	if (i == numqcpics)
 		numqcpics++;
@@ -5381,7 +5401,7 @@ static void PF_cl_getrenderentity (void)
 	vec3_t						tmp;
 	size_t						entnum = G_FLOAT (OFS_PARM0);
 	enum getrenderentityfield_e fldnum = G_FLOAT (OFS_PARM1);
-	
+
 #if 0 // vso : Always authorize it, who cares...
 	if (qcvm->nogameaccess)
 	{

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -5333,6 +5333,196 @@ static void PF_checkpvs (void)
 	G_FLOAT (OFS_RETURN) = false;
 }
 
+enum getrenderentityfield_e
+{
+	// DP's range
+	GE_MAXENTS = -1,
+	GE_ACTIVE = 0,
+	GE_ORIGIN = 1,
+	GE_FORWARD = 2,
+	GE_RIGHT = 3,
+	GE_UP = 4,
+	GE_SCALE = 5,
+	GE_ORIGINANDVECTORS = 6,
+	GE_ALPHA = 7,
+	GE_COLORMOD = 8,
+	// GE_PANTSCOLOR = 9,
+	// GE_SHIRTCOLOR = 10,
+	GE_SKIN = 11,
+	//	GE_MINS				= 12,
+	//	GE_MAXS				= 13,
+	//	GE_ABSMIN			= 14,
+	//	GE_ABSMAX			= 15,
+	//	GE_LIGHT			= 16,
+
+	// FTE's range.
+	GE_MODELINDEX = 200,
+	//	GE_MODELINDEX2		= 201,
+	GE_EFFECTS = 202,
+	GE_FRAME = 203,
+	GE_ANGLES = 204,
+	//	GE_FATNESS			= 205,
+	//	GE_DRAWFLAGS		= 206,
+	//	GE_ABSLIGHT			= 207,
+	//	GE_GLOWMOD			= 208,
+	//	GE_GLOWSIZE			= 209,
+	//	GE_GLOWCOLOUR		= 210,
+	//	GE_RTSTYLE			= 211,
+	//	GE_RTPFLAGS			= 212,
+	//	GE_RTCOLOUR			= 213,
+	//	GE_RTRADIUS			= 214,
+	GE_TAGENTITY = 215,
+	GE_TAGINDEX = 216,
+	//	GE_GRAVITYDIR		= 217,
+	GE_TRAILEFFECTNUM = 218,
+};
+static void PF_cl_getrenderentity (void)
+{
+	vec3_t						tmp;
+	size_t						entnum = G_FLOAT (OFS_PARM0);
+	enum getrenderentityfield_e fldnum = G_FLOAT (OFS_PARM1);
+	
+#if 0 // vso : Always authorize it, who cares...
+	if (qcvm->nogameaccess)
+	{
+		G_FLOAT (OFS_RETURN + 0) = 0;
+		G_FLOAT (OFS_RETURN + 1) = 0;
+		G_FLOAT (OFS_RETURN + 2) = 0;
+		Con_Printf ("PF_getrenderentity: not permitted\n");
+		return;
+	}
+#endif
+
+	if (fldnum == GE_MAXENTS)
+		G_FLOAT (OFS_RETURN + 0) = cl.num_entities;
+	else if (entnum >= cl.num_entities || !cl.entities[entnum].model)
+	{
+		G_FLOAT (OFS_RETURN + 0) = 0;
+		G_FLOAT (OFS_RETURN + 1) = 0;
+		G_FLOAT (OFS_RETURN + 2) = 0;
+	}
+	else
+		switch (fldnum)
+		{
+		case GE_ACTIVE:
+			G_FLOAT (OFS_RETURN + 0) = true;
+			break;
+		case GE_ORIGIN:
+			VectorCopy (cl.entities[entnum].origin, G_VECTOR (OFS_RETURN));
+			break;
+		case GE_ORIGINANDVECTORS:
+			VectorCopy (cl.entities[entnum].origin, G_VECTOR (OFS_RETURN));
+			VectorCopy (cl.entities[entnum].angles, tmp);
+			if (cl.entities[entnum].model->type == mod_alias)
+				tmp[0] *= -1;
+			AngleVectors (tmp, pr_global_struct->v_forward, pr_global_struct->v_right, pr_global_struct->v_up);
+			break;
+		case GE_FORWARD:
+			VectorCopy (cl.entities[entnum].angles, tmp);
+			if (cl.entities[entnum].model->type == mod_alias)
+				tmp[0] *= -1;
+			AngleVectors (tmp, G_VECTOR (OFS_RETURN), tmp, tmp);
+			break;
+		case GE_RIGHT:
+			VectorCopy (cl.entities[entnum].angles, tmp);
+			if (cl.entities[entnum].model->type == mod_alias)
+				tmp[0] *= -1;
+			AngleVectors (tmp, tmp, G_VECTOR (OFS_RETURN), tmp);
+			break;
+		case GE_UP:
+			VectorCopy (cl.entities[entnum].angles, tmp);
+			if (cl.entities[entnum].model->type == mod_alias)
+				tmp[0] *= -1;
+			AngleVectors (tmp, tmp, tmp, G_VECTOR (OFS_RETURN));
+			break;
+		case GE_SCALE:
+			G_FLOAT (OFS_RETURN + 0) = ENTSCALE_DECODE (cl.entities[entnum].netstate.scale);
+			break;
+		case GE_ALPHA:
+			G_FLOAT (OFS_RETURN + 0) = ENTALPHA_DECODE (cl.entities[entnum].alpha);
+			break;
+		case GE_COLORMOD:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].netstate.colormod[0] / 32.0;
+			G_FLOAT (OFS_RETURN + 1) = cl.entities[entnum].netstate.colormod[1] / 32.0;
+			G_FLOAT (OFS_RETURN + 2) = cl.entities[entnum].netstate.colormod[2] / 32.0;
+			break;
+		/*
+		case GE_PANTSCOLOR:
+		{
+			int	  palidx = cl.entities[entnum].netstate.colormap;
+			byte *pal;
+			if ((cl.entities[entnum].netstate.eflags & EFLAGS_COLOURMAPPED) || palidx >= cl.maxclients)
+				pal = (byte *)d_8to24table + 4 * Sbar_ColorForMap (palidx & 0x0f);
+			else
+				pal = CL_PLColours_ToRGB (&cl.scores[palidx].pants);
+			G_FLOAT (OFS_RETURN + 0) = pal[0] / 255.0;
+			G_FLOAT (OFS_RETURN + 1) = pal[1] / 255.0;
+			G_FLOAT (OFS_RETURN + 2) = pal[2] / 255.0;
+		}
+		break;
+		case GE_SHIRTCOLOR:
+		{
+			int	  palidx = cl.entities[entnum].netstate.colormap;
+			byte *pal;
+			if ((cl.entities[entnum].netstate.eflags & EFLAGS_COLOURMAPPED) || palidx >= cl.maxclients)
+				pal = (byte *)d_8to24table + 4 * Sbar_ColorForMap (palidx & 0xf0);
+			else
+				pal = CL_PLColours_ToRGB (&cl.scores[palidx].shirt);
+			G_FLOAT (OFS_RETURN + 0) = pal[0] / 255.0;
+			G_FLOAT (OFS_RETURN + 1) = pal[1] / 255.0;
+			G_FLOAT (OFS_RETURN + 2) = pal[2] / 255.0;
+		}
+		break;
+		*/
+		case GE_SKIN:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].skinnum;
+			break;
+			//	case GE_MINS:
+			//	case GE_MAXS:
+			//	case GE_ABSMIN:
+			//	case GE_ABSMAX:
+			//	case GE_LIGHT:
+		case GE_MODELINDEX:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].netstate.modelindex;
+			break;
+			//	case GE_MODELINDEX2:
+		case GE_EFFECTS:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].effects;
+			break;
+		case GE_FRAME:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].frame;
+			break;
+		case GE_ANGLES:
+			VectorCopy (cl.entities[entnum].angles, G_VECTOR (OFS_RETURN));
+			break;
+			//	case GE_FATNESS:
+			//	case GE_DRAWFLAGS:
+			//	case GE_ABSLIGHT:
+			//	case GE_GLOWMOD:
+			//	case GE_GLOWSIZE:
+			//	case GE_GLOWCOLOUR:
+			//	case GE_RTSTYLE:
+			//	case GE_RTPFLAGS:
+			//	case GE_RTCOLOUR:
+			//	case GE_RTRADIUS:
+		case GE_TAGENTITY:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].netstate.tagentity;
+			break;
+		case GE_TAGINDEX:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].netstate.tagindex;
+			break;
+			//	case GE_GRAVITYDIR:
+		case GE_TRAILEFFECTNUM:
+			G_FLOAT (OFS_RETURN + 0) = cl.entities[entnum].netstate.traileffectnum;
+			break;
+
+		case GE_MAXENTS:
+		default:
+			Con_Printf ("PF_cl_getrenderentity(,%i): not implemented\n", fldnum);
+			break;
+		}
+}
+
 // A quick note on number ranges.
 // 0: automatically assigned. more complicated, but no conflicts over numbers, just names...
 //    NOTE: #0 is potentially ambiguous - vanilla will interpret it as instruction 0 (which is normally reserved) rather than a builtin.
@@ -5551,6 +5741,7 @@ static struct
 	{"getentityfieldstring",		PF_getentfldstr,				PF_getentfldstr,				499,	"string(float fieldnum, entity ent)"},//DP_QC_ENTITYDATA
 	{"putentityfieldstring",		PF_putentfldstr,				PF_putentfldstr,				500,	"float(float fieldnum, entity ent, string s)"},//DP_QC_ENTITYDATA
 	{"whichpack",					PF_whichpack,					PF_whichpack,					503,	D("string(string filename, optional float makereferenced)", "Returns the pak file name that contains the file specified. progs/player.mdl will generally return something like 'pak0.pak'. If makereferenced is true, clients will automatically be told that the returned package should be pre-downloaded and used, even if allow_download_refpackages is not set.")},//DP_QC_WHICHPACK
+	{"getentity",					PF_NoSSQC,						PF_cl_getrenderentity,			504,	D("__variant(float entnum, float fieldnum)", "Looks up fields from non-csqc-visible entities. The entity will need to be within the player's pvs. fieldnum should be one of the GE_ constants.")},//DP_CSQC_QUERYRENDERENTITY
 	{"uri_escape",					PF_uri_escape,					PF_uri_escape,					510,	"string(string in)"},//DP_QC_URI_ESCAPE
 	{"uri_unescape",				PF_uri_unescape,				PF_uri_unescape,				511,	"string(string in)"},//DP_QC_URI_ESCAPE
 	{"num_for_edict",				PF_num_for_edict,				PF_num_for_edict,				512,	"float(entity ent)"},//DP_QC_NUM_FOR_EDICT
@@ -5635,6 +5826,7 @@ static struct
 } qcextensions[] = {
 	{"DP_CON_SET"},
 	{"DP_CON_SETA"},
+	{"DP_CSQC_QUERYRENDERENTITY"},
 	//	{"DP_EF_NOSHADOW"},
 	{"DP_ENT_ALPHA", PR_Can_Ent_Alpha}, // already in quakespasm, supposedly.
 	{"DP_ENT_COLORMOD", PR_Can_Ent_ColorMod},

--- a/Quake/snd_codec.c
+++ b/Quake/snd_codec.c
@@ -294,10 +294,11 @@ snd_stream_t *S_CodecUtilOpen (const char *filename, snd_codec_t *codec, qboolea
 	snd_stream_t *stream;
 	FILE		 *handle;
 	qboolean	  pak;
-	long		  length;
+	qfilesize_t	  length;
 
 	/* Try to open the file */
-	length = (long)COM_FOpenFile (filename, &handle, NULL);
+	length = COM_FOpenFile (filename, &handle, NULL);
+
 	pak = file_from_pak;
 	if (length == -1)
 	{
@@ -310,7 +311,7 @@ snd_stream_t *S_CodecUtilOpen (const char *filename, snd_codec_t *codec, qboolea
 	stream->codec = codec;
 	stream->loop = loop;
 	stream->fh.file = handle;
-	stream->fh.start = ftell (handle);
+	stream->fh.start = Sys_ftell (handle);
 	stream->fh.pos = 0;
 	stream->fh.length = length;
 	stream->fh.pak = stream->pak = pak;

--- a/Quake/snd_wave.c
+++ b/Quake/snd_wave.c
@@ -100,7 +100,7 @@ static int WAV_FindRIFFChunk (FILE *f, const char *chunk)
 		len = ((len + 1) & ~1); /* pad by 2 . */
 
 		/* Not the right chunk - skip it */
-		fseek (f, len, SEEK_CUR);
+		Sys_fseek (f, len, SEEK_CUR);
 	}
 
 	return -1;
@@ -157,7 +157,7 @@ static qboolean WAV_ReadRIFFHeader (const char *name, FILE *file, snd_info_t *in
 	if (fmtlen > 16)
 	{
 		fmtlen -= 16;
-		fseek (file, fmtlen, SEEK_CUR);
+		Sys_fseek (file, fmtlen, SEEK_CUR);
 	}
 
 	/* Scan for the data chunk */
@@ -198,7 +198,7 @@ static qboolean S_WAV_CodecOpenStream (snd_stream_t *stream)
 	if (!WAV_ReadRIFFHeader (stream->name, stream->fh.file, &stream->info))
 		return false;
 
-	stream->fh.start = ftell (stream->fh.file); /* reset to data position */
+	stream->fh.start = Sys_ftell (stream->fh.file); /* reset to data position */
 	if (stream->fh.start - start + stream->info.size > stream->fh.length)
 	{
 		Con_Printf ("%s data size mismatch\n", stream->name);

--- a/Quake/sys.h
+++ b/Quake/sys.h
@@ -23,57 +23,85 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define _QUAKE_SYS_H
 
 // sys.h -- non-portable functions
-
+void Sys_FileInit (void);
 void Sys_Init (void);
 
 //
-// file IO
+// file IO : support huge files > 2GB (qfilesize_t), and huge file seeks > 2**31 bytes (qfileofs_t)
 //
+typedef long long qfilesize_t;
+typedef long long qfileofs_t;
 
-typedef int64_t qfileofs_t;
+// return 0 on success
+// origin is SEEK_CUR / SEEK_END / SEEK_SET
+int Sys_fseek (FILE *file, qfileofs_t ofs, int origin);
 
-int		   Sys_fseek (FILE *file, qfileofs_t ofs, int origin);
-qfileofs_t Sys_ftell (FILE *file);
-qfileofs_t Sys_filelength (FILE *f);
+qfileofs_t	Sys_ftell (FILE *file);
+qfilesize_t Sys_filelength (FILE *f);
+
+int Sys_fgetc (int handle);
 
 // returns the file size or -1 if file is not present.
 // the file should be in BINARY mode for stupid OSs that care
-qfileofs_t Sys_FileOpenRead (const char *path, int *hndl);
+qfilesize_t Sys_FileOpenRead (const char *path, int *hndl);
 
-void Sys_MemFileOpenRead (const byte *memory, int size, int *hndl);
+void Sys_MemFileOpenRead (const byte *memory, qfilesize_t size, int *hndl);
+
+// Duplicate a (read) handle : make a copy of a given handle designating the same resource,
+// to independently seek and read from the original handle.
+int Sys_DuplicateHandle (int handle);
 
 // Returns a file handle
 int Sys_FileOpenWrite (const char *path);
 
+// same as Sys_filelength, but for handles.
+qfilesize_t Sys_FileSize (int handle);
+
+// same as Sys_ftell, but for handles.
+qfileofs_t Sys_FilePos (int handle);
+
 void Sys_FileClose (int handle);
-void Sys_FileSeek (int handle, int position);
-int	 Sys_FileRead (int handle, void *dest, int count);
-int	 Sys_FileWrite (int handle, const void *data, int count);
+
+// Sys_FileSeek return 0 on success like fseek().
+int Sys_FileSeek (int handle, qfileofs_t position);
+
+// fgetc() but for handles. Return EOF if
+// we attenpt to read beyound the end of file.
+int Sys_fgetc (int handle);
+
+// feof() but for handles. Return true if we are in EOF condition. (Valid only for read file)
+bool Sys_feof (int handle);
+
+// A single File read/write is limited to 2**31 bytes, should be enough in all cases.
+int Sys_FileRead (int handle, void *dest, int count);
+int Sys_FileWrite (int handle, const void *data, int count);
+
 void Sys_mkdir (const char *path);
 
-int Sys_FileType (const char *path);
 /* returns an FS entity type, i.e. FS_ENT_FILE or FS_ENT_DIRECTORY.
  * returns FS_ENT_NONE (0) if no such file or directory is present. */
+int Sys_FileType (const char *path);
 
 //
 // system IO
 //
 FUNC_NORETURN void Sys_Quit (void);
-FUNC_NORETURN void Sys_Error (const char *error, ...) FUNC_PRINTF (1, 2);
-// an error will cause the entire program to exit
 
+// An error that will cause the entire program to exit. Can be safely called from any thread.
+FUNC_NORETURN void Sys_Error (const char *error, ...) FUNC_PRINTF (1, 2);
+
+// Print a message on the system console (NOT the Quake console !). Can be safely called from any thread.
 void Sys_Printf (const char *fmt, ...) FUNC_PRINTF (1, 2);
-// send text to the console
 
 double Sys_DoubleTime (void);
 
 const char *Sys_ConsoleInput (void);
 
-void Sys_Sleep (unsigned long msecs);
 // yield for about 'msecs' milliseconds.
+void Sys_Sleep (unsigned long msecs);
 
-void Sys_SendKeyEvents (void);
 // Perform Key_Event () callbacks until the input que is empty
+void Sys_SendKeyEvents (void);
 
 // Pin the calling Thread to core core_index, return true if succcessfull
 bool Sys_PinCurrentThread (int core_index);

--- a/Quake/sys_sdl.c
+++ b/Quake/sys_sdl.c
@@ -28,29 +28,67 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef struct file_handle_s
 {
+	bool		free;
+	char	   *file_path;
 	FILE	   *file;
 	const byte *memory;
-	int			pos;
-	int			size;
+	qfileofs_t	pos;
+	qfilesize_t size;
+	bool		eof_condition;
 } file_handle_t;
 
-#define MAX_HANDLES 32 /* johnfitz -- was 10 */
-static file_handle_t sys_handles[MAX_HANDLES];
+// Protects sys_handles when requesting a new handle / freeing a handle.
+static SDL_Mutex *sys_handles_mutex;
 
-static int findhandle (void)
+#define MAX_HANDLES 32 /* johnfitz -- was 10 */
+static file_handle_t sys_handles[MAX_HANDLES * (TASKS_MAX_WORKERS + 1)];
+
+void Sys_FileInit (void)
+{
+	sys_handles_mutex = SDL_CreateMutex ();
+
+	memset (sys_handles, 0x0, sizeof (sys_handles));
+
+	for (int i = 1; i < countof (sys_handles); i++)
+		sys_handles[i].free = true;
+}
+
+static int allocHandle (void)
 {
 	int i;
 
-	for (i = 1; i < MAX_HANDLES; i++)
+	SDL_LockMutex (sys_handles_mutex);
+
+	// TBC : why skipping index 0 ? is it to make
+	// 0 as an invalid handle value by design ?
+	for (i = 1; i < countof (sys_handles); i++)
 	{
-		if (!sys_handles[i].file && !sys_handles[i].memory)
+		if (sys_handles[i].free)
+		{
+			// reset all fields
+			memset (&(sys_handles[i]), 0x0, sizeof (file_handle_t));
+
+			assert (!sys_handles[i].free);
+
+			SDL_UnlockMutex (sys_handles_mutex);
 			return i;
+		}
 	}
+	SDL_UnlockMutex (sys_handles_mutex);
 	Sys_Error ("out of handles");
 	return -1;
 }
 
-qfileofs_t Sys_filelength (FILE *f)
+static void freeHandle (int handle)
+{
+	SDL_LockMutex (sys_handles_mutex);
+
+	sys_handles[handle].free = true;
+
+	SDL_UnlockMutex (sys_handles_mutex);
+}
+
+qfilesize_t Sys_filelength (FILE *f)
 {
 	qfileofs_t pos, end;
 
@@ -59,15 +97,16 @@ qfileofs_t Sys_filelength (FILE *f)
 	end = Sys_ftell (f);
 	Sys_fseek (f, pos, SEEK_SET);
 
-	return end;
+	return (qfilesize_t)end;
 }
 
-qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
+qfilesize_t Sys_FileOpenRead (const char *path, int *hndl)
 {
-	FILE *f;
-	int	  i, retval;
+	FILE	   *f;
+	int			i;
+	qfilesize_t retval;
 
-	i = findhandle ();
+	i = allocHandle ();
 	f = fopen (path, "rb");
 
 	if (!f)
@@ -77,22 +116,68 @@ qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
 	}
 	else
 	{
+		sys_handles[i].memory = NULL;
+
+		sys_handles[i].file_path = (char *)Mem_Alloc (strlen (path) + 1);
+		q_strlcpy (sys_handles[i].file_path, (const char *)path, strlen (path) + 1);
+
 		sys_handles[i].file = f;
+		sys_handles[i].pos = 0;
+		sys_handles[i].eof_condition = false;
 		*hndl = i;
 		retval = Sys_filelength (f);
+		sys_handles[i].size = retval;
 	}
 
 	return retval;
 }
 
-void Sys_MemFileOpenRead (const byte *memory, int size, int *hndl)
+void Sys_MemFileOpenRead (const byte *memory, qfilesize_t size, int *hndl)
 {
-	int i = findhandle ();
+	int i = allocHandle ();
 
+	sys_handles[i].file = NULL;
+	sys_handles[i].file_path = NULL;
 	sys_handles[i].memory = memory;
 	sys_handles[i].size = size;
+	// position to start reading from :
 	sys_handles[i].pos = 0;
+	sys_handles[i].eof_condition = false;
 	*hndl = i;
+}
+
+int Sys_DuplicateHandle (int handle)
+{
+	FILE *new_file = NULL;
+
+	if (sys_handles[handle].file)
+	{
+		new_file = fopen (sys_handles[handle].file_path, "rb");
+
+		if (!new_file)
+			return -1;
+	}
+
+	int new_handle = allocHandle ();
+
+	// duplicate all data
+	sys_handles[new_handle] = sys_handles[handle];
+
+	// replace with the new file
+	if (sys_handles[handle].file)
+	{
+		sys_handles[new_handle].file = new_file;
+
+		// we want our own copy, will be freed in Sys_FileClose()
+		sys_handles[new_handle].file_path = (char *)Mem_Alloc (strlen (sys_handles[handle].file_path) + 1);
+		q_strlcpy (sys_handles[new_handle].file_path, (const char *)sys_handles[handle].file_path, strlen (sys_handles[handle].file_path) + 1);
+	}
+
+	// Re-Seek:
+	Sys_FileSeek (new_handle, sys_handles[handle].pos);
+	sys_handles[new_handle].eof_condition = false;
+
+	return new_handle;
 }
 
 int Sys_FileOpenWrite (const char *path)
@@ -100,14 +185,28 @@ int Sys_FileOpenWrite (const char *path)
 	FILE *f;
 	int	  i;
 
-	i = findhandle ();
+	i = allocHandle ();
 	f = fopen (path, "wb");
 
 	if (!f)
 		Sys_Error ("Error opening %s: %s", path, strerror (errno));
 
 	sys_handles[i].file = f;
+
+	sys_handles[i].file_path = (char *)Mem_Alloc (strlen (path) + 1);
+	q_strlcpy (sys_handles[i].file_path, (const char *)path, strlen (path) + 1);
+
+	sys_handles[i].size = Sys_filelength (f);
+	// position to start writing from :
+	sys_handles[i].pos = sys_handles[i].size;
+	sys_handles[i].eof_condition = false;
+	sys_handles[i].memory = NULL;
 	return i;
+}
+
+qfileofs_t Sys_FilePos (int handle)
+{
+	return sys_handles[handle].pos;
 }
 
 void Sys_FileClose (int handle)
@@ -115,34 +214,106 @@ void Sys_FileClose (int handle)
 	if (sys_handles[handle].file)
 	{
 		fclose (sys_handles[handle].file);
-		sys_handles[handle].file = NULL;
+		Mem_Free (sys_handles[handle].file_path);
 	}
-	else
-		sys_handles[handle].memory = NULL;
+
+	freeHandle (handle);
 }
 
-void Sys_FileSeek (int handle, int position)
+int Sys_FileSeek (int handle, qfileofs_t position)
 {
-	if (sys_handles[handle].file)
-		fseek (sys_handles[handle].file, position, SEEK_SET);
-	else
+	// like fseek(), going beyond the actual file
+	// without error is expected. Attempting to read afterwards however will trigger
+	// an EOF condition.
+	if (position >= 0)
+	{
+		if (sys_handles[handle].file)
+		{
+			Sys_fseek (sys_handles[handle].file, position, SEEK_SET);
+		}
+
 		sys_handles[handle].pos = position;
+
+		return 0;
+	}
+
+	return 1;
+}
+
+bool Sys_feof (int handle)
+{
+	return sys_handles[handle].eof_condition;
 }
 
 int Sys_FileRead (int handle, void *dest, int count)
 {
+	if (count <= 0)
+		return 0;
+
+	// test EOF condition
+	sys_handles[handle].eof_condition = sys_handles[handle].eof_condition || ((sys_handles[handle].size - sys_handles[handle].pos) <= 0) ? true : false;
+
+	if (sys_handles[handle].eof_condition)
+		return 0;
+
+	qfilesize_t computed_read_count = q_min ((qfilesize_t)count, sys_handles[handle].size - sys_handles[handle].pos);
+
+	computed_read_count = q_max (0, computed_read_count);
+
 	if (sys_handles[handle].file)
-		return fread (dest, 1, count, sys_handles[handle].file);
+	{
+		// file-based:
+		qfilesize_t fread_count = fread (dest, 1, count, sys_handles[handle].file);
+
+		assert (computed_read_count == fread_count);
+		// printf ("computed_read_count (%d) != fread_count(%d)\n", (int)computed_read_count, (int)fread_count);
+
+		sys_handles[handle].pos += fread_count;
+		// if partial read, triggers EOF
+		sys_handles[handle].eof_condition = feof (sys_handles[handle].file);
+
+		return fread_count;
+	}
 	else
 	{
-		memcpy (dest, sys_handles[handle].memory + sys_handles[handle].pos, count);
-		sys_handles[handle].pos += count;
-		return count;
+		// memory-based:
+		memcpy (dest, sys_handles[handle].memory + sys_handles[handle].pos, computed_read_count);
+
+		sys_handles[handle].pos += computed_read_count;
+
+		// if partial read, triggers EOF
+		sys_handles[handle].eof_condition = ((sys_handles[handle].size - sys_handles[handle].pos) <= 0);
+
+		return computed_read_count;
 	}
+
+	return 0;
+}
+
+int Sys_fgetc (int handle)
+{
+	if (sys_handles[handle].eof_condition)
+		return EOF;
+
+	int next_byte_read = 0;
+
+	if (Sys_FileRead (handle, (void *)&next_byte_read, 1) != 1)
+	{
+		assert (sys_handles[handle].eof_condition);
+		return EOF;
+	}
+
+	return next_byte_read;
 }
 
 int Sys_FileWrite (int handle, const void *data, int count)
 {
 	assert (sys_handles[handle].file);
-	return fwrite (data, 1, count, sys_handles[handle].file);
+
+	const int effective_nb_write = fwrite (data, 1, count, sys_handles[handle].file);
+
+	sys_handles[handle].pos += effective_nb_write;
+	sys_handles[handle].size += effective_nb_write;
+
+	return effective_nb_write;
 }

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -217,6 +217,8 @@ static void Sys_GetBasedir (char *argv0, char *dst, size_t dstsize)
 
 void Sys_Init (void)
 {
+	Sys_FileInit ();
+
 	memset (cwd, 0, sizeof (cwd));
 	Sys_GetBasedir (host_parms->argv[0], cwd, sizeof (cwd));
 	host_parms->basedir = cwd;
@@ -253,7 +255,8 @@ static const char errortxt2[] = "\nQUAKE ERROR: ";
 
 void Sys_Error (const char *error, ...)
 {
-	host_parms->errstate++;
+	if (!Tasks_IsWorker ())
+		host_parms->errstate++;
 
 	va_list argptr;
 	va_start (argptr, error);
@@ -271,16 +274,22 @@ void Sys_Error (const char *error, ...)
 		Mem_Free (captured_stack_trace);
 	}
 
-	PR_SwitchQCVM (NULL);
+	if (!Tasks_IsWorker ())
+		PR_SwitchQCVM (NULL);
 
 	fputs (errortxt1, stdout);
-	Host_Shutdown ();
+
+	if (!Tasks_IsWorker ())
+		Host_Shutdown ();
+
 	fputs (errortxt2, stdout);
 
 	Sys_Printf ("%s\n\n", text);
 
-	if (!isDedicated && !Sys_IsInDebugger ())
+	if (!Tasks_IsWorker () && !isDedicated && !Sys_IsInDebugger ())
+	{
 		PL_ErrorDialog (text);
+	}
 
 	Mem_Free (text);
 

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -143,6 +143,8 @@ static void Sys_SetTimerResolution (void)
 
 void Sys_Init (void)
 {
+	Sys_FileInit ();
+
 	Sys_SetTimerResolution ();
 	Sys_SetDPIAware ();
 
@@ -228,7 +230,8 @@ static const char errortxt2[] = "\nQUAKE ERROR: ";
 
 void Sys_Error (const char *error, ...)
 {
-	host_parms->errstate++;
+	if (!Tasks_IsWorker ())
+		host_parms->errstate++;
 
 	va_list argptr;
 	DWORD	dummy;
@@ -250,9 +253,10 @@ void Sys_Error (const char *error, ...)
 		Mem_Free (captured_stack_trace);
 	}
 
-	PR_SwitchQCVM (NULL);
+	if (!Tasks_IsWorker ())
+		PR_SwitchQCVM (NULL);
 
-	if (isDedicated)
+	if (Tasks_IsWorker () || isDedicated)
 		WriteFile (houtput, errortxt1, strlen (errortxt1), &dummy, NULL);
 	/* SDL will put these into its own stderr log,
 	   so print to stderr even in graphical mode. */
@@ -261,7 +265,7 @@ void Sys_Error (const char *error, ...)
 
 	Sys_Printf ("%s\n\n", text);
 
-	if (!isDedicated && !Sys_IsInDebugger ())
+	if (!Tasks_IsWorker () && !isDedicated && !Sys_IsInDebugger ())
 	{
 		PL_ErrorDialog (text);
 	}
@@ -289,7 +293,7 @@ void Sys_Printf (const char *fmt, ...)
 
 	va_end (argptr);
 
-	if (isDedicated)
+	if (Tasks_IsWorker () || isDedicated)
 	{
 		WriteFile (houtput, output_buffer, strlen (output_buffer), &dummy, NULL);
 	}

--- a/Quake/wad.c
+++ b/Quake/wad.c
@@ -116,15 +116,14 @@ void W_LoadWadFile (void) // johnfitz -- filename is now hard-coded for honesty
 		{
 			if (lump_p->filepos > com_filesize || lump_p->size < 0)
 			{
-				Con_Printf (
-					"Wad file %s lump \"%.16s\" begins %" SDL_PRIs64 " bytes beyond end of wad\n", filename, lump_p->name, lump_p->filepos - com_filesize);
+				Con_Printf ("Wad file %s lump \"%.16s\" begins %lld bytes beyond end of wad\n", filename, lump_p->name, lump_p->filepos - com_filesize);
 				lump_p->filepos = 0;
 				lump_p->size = q_max (0, lump_p->size - lump_p->filepos);
 			}
 			else
 			{
 				Con_Printf (
-					"Wad file %s lump \"%.16s\" extends %" SDL_PRIs64 " bytes beyond end of wad (lump size: %u)\n", filename, lump_p->name,
+					"Wad file %s lump \"%.16s\" extends %lld bytes beyond end of wad (lump size: %u)\n", filename, lump_p->name,
 					(lump_p->filepos + lump_p->size) - com_filesize, lump_p->size);
 				lump_p->size = q_max (0, lump_p->size - lump_p->filepos);
 			}
@@ -178,14 +177,14 @@ W_OpenWadFile
 static qboolean W_OpenWadFile (const char *filename, fshandle_t *fh)
 {
 	FILE *f;
-	long  length;
 
-	length = (long)COM_FOpenFile (filename, &f, NULL);
+	const qfilesize_t length = COM_FOpenFile (filename, &f, NULL);
+
 	if (length == -1)
 		return false;
 
 	fh->file = f;
-	fh->start = ftell (f);
+	fh->start = Sys_ftell (f);
 	fh->pos = 0;
 	fh->length = length;
 	fh->pak = file_from_pak;
@@ -248,7 +247,7 @@ static wad_t *W_AddWadFile (const char *name, fshandle_t *fh)
 		{
 			if (info->filepos > fh->length || info->size < 0)
 			{
-				Con_Warning ("WAD file %s lump \"%.16s\" begins %li bytes beyond end of WAD\n", name, info->name, info->filepos - fh->length);
+				Con_Warning ("WAD file %s lump \"%.16s\" begins %lld bytes beyond end of WAD\n", name, info->name, (qfilesize_t)info->filepos - fh->length);
 
 				info->filepos = 0;
 				info->size = q_max (0, info->size - info->filepos);
@@ -256,8 +255,8 @@ static wad_t *W_AddWadFile (const char *name, fshandle_t *fh)
 			else
 			{
 				Con_Warning (
-					"WAD file %s lump \"%.16s\" extends %li bytes beyond end of WAD (lump size is %i)\n", name, info->name,
-					(info->filepos + info->size) - fh->length, info->size);
+					"WAD file %s lump \"%.16s\" extends %lld bytes beyond end of WAD (lump size is %i)\n", name, info->name,
+					(qfilesize_t)(info->filepos + info->size) - fh->length, info->size);
 
 				info->size = q_max (0, info->size - info->filepos);
 			}

--- a/meson.build
+++ b/meson.build
@@ -240,7 +240,7 @@ srcs = [
 	 run_generate_embedded_pak,
 ]
 
-cflags = ['-Wall', '-Wno-trigraphs', '-Werror', '-std=gnu11']
+cflags = ['-Wall', '-Wno-trigraphs', '-Werror', '-std=gnu11', '-D_FILE_OFFSET_BITS=64']
 
 if use_sdl3
     sdl_dep = dependency('sdl3')


### PR DESCRIPTION
Add all available image formats for drawing Hud elements like everywhere else (png tga jpg pcx) + Filesystem fixes :
- 2D drawing functions (Draw_CachePic...) functions including HUD CSQC now accepts true-color textures as input (png, tga, jpg) not only .lmp
  using Image_LoadImage to load textures as everywhere else.
- Draw_CachePic : For .lmp inputs, true-color overrides are loaded instead if they are present.
  Ex. Draw_CachePic("gfx/conback.lmp") loads  gfx/conback.png if available.

Filesystem :
- Functions using handles (ex: COM_OpenFile) were not safe for concurrent usage on the same underlaying resource, ex. especially in .pak
- Functions using handles were unable to access memory-based resources (ex: the embedded vkquake.pak)
- Use > 2GB - capable calls consistently when possible, were previously localized only on demo-related functions.