### PR TITLE
AppImage: build the bundled SDL3 with the Wayland video driver

### DIFF
--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -15,21 +15,26 @@ RUN apt-get update \
 	ninja-build \
 	libasound2-dev \
 	libaudiofile-dev \
+	libcairo2-dev \
 	libdbus-1-dev \
+	libegl1-mesa-dev \
 	libibus-1.0-dev \
 	libmad0-dev \
 	libopenal-dev \
+	libpango1.0-dev \
 	libpulse-dev \
 	libsndio-dev \
 	libudev-dev \
 	libusb-dev \
 	libvorbis-dev \
 	libvulkan-dev \
+	libwayland-dev \
 	libx11-xcb-dev \
 	libxcursor-dev \
 	libxext-dev \
 	libxfixes-dev \
 	libxi-dev \
+	libxkbcommon-dev \
 	libxrandr-dev \
 	libxss-dev \
 	libxt-dev \
@@ -40,8 +45,32 @@ RUN apt-get update \
 	libopus-dev \
 	libopusfile-dev \
 	vulkan-sdk \
+	wayland-protocols \
 	zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp \
+ && wget https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip \
+ && unzip ninja-linux.zip \
+ && rm ninja-linux.zip \
+ && cp ninja /usr/bin/ninja
+
+RUN cd /opt \
+ && wget https://github.com/mesonbuild/meson/releases/download/1.3.1/meson-1.3.1.tar.gz \
+ && tar -xzf meson-1.3.1.tar.gz \
+ && rm meson-1.3.1.tar.gz \
+ && mv meson-1.3.1 meson
+
+# headers for SDL's dynamically loaded libdecor support (window
+# decorations on GNOME); focal has no libdecor package
+RUN cd /tmp \
+ && wget https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.2.3/libdecor-0.2.3.tar.gz \
+ && tar -xzf libdecor-0.2.3.tar.gz \
+ && rm libdecor-0.2.3.tar.gz \
+ && cd /tmp/libdecor-0.2.3 \
+ && python3 /opt/meson/meson.py setup build -Ddemo=false -Dgtk=disabled \
+ && ninja -C build install \
+ && ldconfig
 
 RUN cd /tmp \
  && wget https://www.libsdl.org/release/SDL2-2.32.8.tar.gz \
@@ -57,20 +86,9 @@ RUN cd /tmp \
  && tar -xzf SDL3-3.4.12.tar.gz \
  && rm SDL3-3.4.12.tar.gz \
  && cd /tmp/SDL3-3.4.12 \
- && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+ && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSDL_WAYLAND=ON -DSDL_X11=ON \
+ && grep -qr "#define SDL_VIDEO_DRIVER_WAYLAND 1" build \
+ && grep -qr "#define SDL_VIDEO_DRIVER_X11 1" build \
  && cmake --build build -j$(nproc) \
  && cmake --install build \
  && ldconfig
-
-RUN cd /tmp \
- && wget https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip \
- && unzip ninja-linux.zip \
- && rm ninja-linux.zip \
- && cp ninja /usr/bin/ninja
-
-RUN cd /opt \
- && wget https://github.com/mesonbuild/meson/releases/download/1.3.1/meson-1.3.1.tar.gz \
- && tar -xzf meson-1.3.1.tar.gz \
- && rm meson-1.3.1.tar.gz \
- && mv meson-1.3.1 meson
- 


### PR DESCRIPTION
The X11-only SDL3 forced the AppImage through XWayland, causing unstable fullscreen frame pacing and intermittently broken relative mouse mode (reported on Fedora 44 + NVIDIA; the same binary works with a system, wayland-enabled libSDL3).

SDL3 vendors its wayland protocol XMLs and dlopens libwayland, xkbcommon and libdecor at runtime, so only build time headers are needed and the glibc floor stays at Ubuntu 20.04: add the wayland/xkbcommon/EGL dev packages, build libdecor 0.2.3 from source (no focal package; SDL needs
>= 0.2.0 headers for its dynamically loaded window decoration support on
GNOME), and fail the image build if either video driver did not get enabled, since SDL_WAYLAND=ON silently degrades when dependencies are missing.