### PR TITLE
Meson Windows support, portable build flags, Ubuntu 22.04 AppImage

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dependencies
       run: brew install molten-vk vulkan-headers glslang spirv-tools sdl2 sdl3 libvorbis flac opus opusfile flac mpg123 meson
     - name: Build vkQuake
-      run: meson build --buildtype=${{ matrix.configuration }} -Ddebug=true -Dstrip=false -Duse_sdl3=${{ matrix.use-sdl3 }} && ninja -C build
+      run: meson setup build --buildtype=${{ matrix.configuration }} -Ddebug=true -Dstrip=false -Duse_sdl3=${{ matrix.use-sdl3 }} && ninja -C build
     - name: Extract debug information and bundle it to .dSYM
       run: |
         dsymutil build/vkquake -o build/vkquake.dSYM

--- a/Misc/vq_pak/mkpak.c
+++ b/Misc/vq_pak/mkpak.c
@@ -151,11 +151,21 @@ int main (int argc, char *argv[])
 		size_t in_size = (size_t)ftell (in);
 		fseek (in, 0, SEEK_SET);
 		in_buffer = realloc (in_buffer, in_size);
-		fread (in_buffer, in_size, 1, in);
+		if (in_size != 0 && fread (in_buffer, in_size, 1, in) != 1)
+		{
+			fprintf (stderr, "Could not read input file '%s', index %d", input_file_path, file_index);
+			return 1;
+		}
 
 		dpackfile_t pack_entry;
 		memset (&pack_entry, 0, sizeof (pack_entry));
-		strncpy (pack_entry.name, entry_path_start, sizeof (pack_entry.name) - 1);
+		const size_t name_len = strlen (entry_path_start);
+		if (name_len >= sizeof (pack_entry.name))
+		{
+			fprintf (stderr, "Entry name '%s' does not fit in the pak directory", entry_path_start);
+			return 1;
+		}
+		memcpy (pack_entry.name, entry_path_start, name_len);
 		pack_entry.filelen = (int)in_size;
 		pack_entry.filepos = file_offset;
 

--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -1,17 +1,19 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
+ARG VULKAN_SDK_VER=1.4.341.1
+ARG MESON_VER=1.3.1
+ARG LIBDECOR_VER=0.2.3
+ARG SDL3_VER=3.4.12
+
 RUN apt-get update \
- && apt-get install -y apt-transport-https ca-certificates wget gnupg apt-utils \
- && wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - \
- && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.275-focal.list https://packages.lunarg.com/vulkan/1.3.275/lunarg-vulkan-1.3.275-focal.list \
- && apt-get update \
  && apt-get install -y \
+	ca-certificates \
+	wget \
 	build-essential \
 	cmake \
 	file \
 	fuse \
-	unzip \
 	ninja-build \
 	libasound2-dev \
 	libaudiofile-dev \
@@ -23,11 +25,11 @@ RUN apt-get update \
 	libopenal-dev \
 	libpango1.0-dev \
 	libpulse-dev \
+	libsdl2-dev \
 	libsndio-dev \
 	libudev-dev \
 	libusb-dev \
 	libvorbis-dev \
-	libvulkan-dev \
 	libwayland-dev \
 	libx11-xcb-dev \
 	libxcursor-dev \
@@ -44,48 +46,50 @@ RUN apt-get update \
 	libflac-dev \
 	libopus-dev \
 	libopusfile-dev \
-	vulkan-sdk \
 	wayland-protocols \
 	zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
+# only the parts of the Vulkan SDK the build uses: shader tools, headers
+# and the loader for linking
 RUN cd /tmp \
- && wget https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip \
- && unzip ninja-linux.zip \
- && rm ninja-linux.zip \
- && cp ninja /usr/bin/ninja
+ && wget -O vulkan-sdk.tar.xz https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VER}/linux/vulkansdk-linux-x86_64-${VULKAN_SDK_VER}.tar.xz \
+ && mkdir -p /opt/vulkan-sdk \
+ && tar -xf vulkan-sdk.tar.xz -C /opt/vulkan-sdk --strip-components=1 --wildcards \
+	${VULKAN_SDK_VER}/x86_64/bin/glslang \
+	${VULKAN_SDK_VER}/x86_64/bin/glslangValidator \
+	${VULKAN_SDK_VER}/x86_64/bin/spirv-opt \
+	${VULKAN_SDK_VER}/x86_64/include \
+	"${VULKAN_SDK_VER}/x86_64/lib/libvulkan.so*" \
+ && rm vulkan-sdk.tar.xz
+
+ENV VULKAN_SDK=/opt/vulkan-sdk/x86_64
+ENV PATH=${VULKAN_SDK}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${VULKAN_SDK}/lib
 
 RUN cd /opt \
- && wget https://github.com/mesonbuild/meson/releases/download/1.3.1/meson-1.3.1.tar.gz \
- && tar -xzf meson-1.3.1.tar.gz \
- && rm meson-1.3.1.tar.gz \
- && mv meson-1.3.1 meson
+ && wget https://github.com/mesonbuild/meson/releases/download/${MESON_VER}/meson-${MESON_VER}.tar.gz \
+ && tar -xzf meson-${MESON_VER}.tar.gz \
+ && rm meson-${MESON_VER}.tar.gz \
+ && mv meson-${MESON_VER} meson
 
 # headers for SDL's dynamically loaded libdecor support (window
-# decorations on GNOME); focal has no libdecor package
+# decorations on GNOME); jammy's libdecor is older than the 0.2.0 SDL
+# needs for dynamic loading
 RUN cd /tmp \
- && wget https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.2.3/libdecor-0.2.3.tar.gz \
- && tar -xzf libdecor-0.2.3.tar.gz \
- && rm libdecor-0.2.3.tar.gz \
- && cd /tmp/libdecor-0.2.3 \
+ && wget https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/${LIBDECOR_VER}/libdecor-${LIBDECOR_VER}.tar.gz \
+ && tar -xzf libdecor-${LIBDECOR_VER}.tar.gz \
+ && rm libdecor-${LIBDECOR_VER}.tar.gz \
+ && cd /tmp/libdecor-${LIBDECOR_VER} \
  && python3 /opt/meson/meson.py setup build -Ddemo=false -Dgtk=disabled \
  && ninja -C build install \
  && ldconfig
 
 RUN cd /tmp \
- && wget https://www.libsdl.org/release/SDL2-2.32.8.tar.gz \
- && tar -xzf SDL2-2.32.8.tar.gz \
- && rm SDL2-2.32.8.tar.gz \
- && cd /tmp/SDL2-2.32.8 \
- && ./configure \
- && make -j \
- && make install
-
-RUN cd /tmp \
- && wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-3.4.12.tar.gz \
- && tar -xzf SDL3-3.4.12.tar.gz \
- && rm SDL3-3.4.12.tar.gz \
- && cd /tmp/SDL3-3.4.12 \
+ && wget https://github.com/libsdl-org/SDL/releases/download/release-${SDL3_VER}/SDL3-${SDL3_VER}.tar.gz \
+ && tar -xzf SDL3-${SDL3_VER}.tar.gz \
+ && rm SDL3-${SDL3_VER}.tar.gz \
+ && cd /tmp/SDL3-${SDL3_VER} \
  && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSDL_WAYLAND=ON -DSDL_X11=ON \
  && grep -qr "#define SDL_VIDEO_DRIVER_WAYLAND 1" build \
  && grep -qr "#define SDL_VIDEO_DRIVER_X11 1" build \

--- a/Packaging/AppImage/run-in-docker.sh
+++ b/Packaging/AppImage/run-in-docker.sh
@@ -9,11 +9,11 @@ cd /usr/src/vkQuake
 rm -rf build/appimage
 rm -rf build/sdl2
 
-python3 /opt/meson/meson.py build/appimage -Ddebug=true -Dstrip=false -Dmp3_lib=mad
+python3 /opt/meson/meson.py setup build/appimage -Ddebug=true -Dstrip=false -Dmp3_lib=mad
 ninja -C build/appimage
 
 # Compile check the SDL2 backend (the AppImage ships SDL3)
-python3 /opt/meson/meson.py build/sdl2 -Ddebug=true -Dstrip=false -Dmp3_lib=mad -Duse_sdl3=disabled
+python3 /opt/meson/meson.py setup build/sdl2 -Ddebug=true -Dstrip=false -Dmp3_lib=mad -Duse_sdl3=disabled
 ninja -C build/sdl2
 
 BIN="build/appimage/vkquake"

--- a/meson.build
+++ b/meson.build
@@ -1,16 +1,28 @@
-project('vkquake', 'c', default_options : ['c_std=gnu11', 'buildtype=release', 'strip=false', 'debug=true', 'b_ndebug=if-release'])
+project(
+    'vkquake',
+    'c',
+    meson_version : '>= 1.3',
+    default_options : ['c_std=gnu11,c11', 'buildtype=release', 'strip=false', 'debug=true', 'b_ndebug=if-release', 'warning_level=1', 'werror=true'])
 
 cc = meson.get_compiler('c')
 
 # Always build keeping frame pointers to get better backtraces
-add_project_arguments(['-fno-omit-frame-pointer'], language: 'c')
+add_project_arguments(cc.get_supported_arguments('-fno-omit-frame-pointer', '/Oy-'), language: 'c')
 
-if cc.has_header_symbol('sched.h', 'CPU_ZERO', prefix: '#define _GNU_SOURCE')
-    message('Info: Task affinity support enabled.')
-    add_project_arguments('-D_GNU_SOURCE', language: 'c')
-else
-    message('Warning: sched.h not found, disabling Task affinity support.')
-    add_project_arguments('-DTASK_AFFINITY_NOT_AVAILABLE', language: 'c')
+if host_machine.system() == 'windows'
+    foreach native : [true, false]
+        add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', '-D_CRT_NONSTDC_NO_DEPRECATE', '-D_WINSOCK_DEPRECATED_NO_WARNINGS', language : 'c', native : native)
+    endforeach
+endif
+
+if host_machine.system() != 'windows'
+    if cc.has_header_symbol('sched.h', 'CPU_ZERO', prefix: '#define _GNU_SOURCE')
+        message('Info: Task affinity support enabled.')
+        add_project_arguments('-D_GNU_SOURCE', language: 'c')
+    else
+        message('Warning: sched.h not found, disabling Task affinity support.')
+        add_project_arguments('-DTASK_AFFINITY_NOT_AVAILABLE', language: 'c')
+    endif
 endif
 
 shaders = [
@@ -40,9 +52,20 @@ shaders = [
 # Prefer SDL3 over SDL2; -Duse_sdl3=enabled requires SDL3, disabled forces SDL2
 use_sdl3_opt = get_option('use_sdl3')
 use_sdl3 = false
-if not use_sdl3_opt.disabled()
-    sdl_dep = dependency('sdl3', required : use_sdl3_opt.enabled())
-    use_sdl3 = sdl_dep.found()
+if host_machine.system() == 'windows'
+    if use_sdl3_opt.disabled()
+        error('SDL2 is not supported on Windows')
+    endif
+    # use the bundled SDL3 like the other Windows builds do
+    sdl_dep = declare_dependency(
+        include_directories : include_directories('Windows/SDL3/include'),
+        dependencies : cc.find_library('SDL3', dirs : meson.project_source_root() / 'Windows/SDL3/lib64'))
+    use_sdl3 = true
+else
+    if not use_sdl3_opt.disabled()
+        sdl_dep = dependency('sdl3', required : use_sdl3_opt.enabled())
+        use_sdl3 = sdl_dep.found()
+    endif
 endif
 if use_sdl3
     add_project_arguments('-DUSE_SDL3', language: 'c')
@@ -54,25 +77,24 @@ endif
 
 glslang = find_program('glslangValidator')
 spirv_opt = find_program('spirv-opt')
-spirv_remap_command = []
-spirv_opt_command  = []
 run_test_canonicalize_ids_spirv_opt = run_command(spirv_opt, '-h', check : false)
 has_canonicalize_ids_spirv_opt = (run_test_canonicalize_ids_spirv_opt.stdout().strip().contains('--canonicalize-ids'))
 bintoc = executable('bintoc', ['Shaders/bintoc.c'], native: true)
 mkpak = executable('mkpak', ['Misc/vq_pak/mkpak.c'], native: true)
+
 if (build_machine.system() == 'darwin') or get_option('buildtype').startswith('debug')
-    spirv_opt_command = [] # MoltenVK spirv-cross has a bug that breaks optimized shaders
-elif has_canonicalize_ids_spirv_opt
-	message('Info: spirv-opt has --canonicalize-ids (glslang >= 16.0).')
-    spirv_opt_command = [spirv_opt, '-Os', '--canonicalize-ids', '--strip-debug', '@PLAINNAME@.spv', '-o', '@PLAINNAME@.spv', '&&']   
-else 
-    spirv_opt_command = [spirv_opt, '-Os', '@PLAINNAME@.spv', '-o', '@PLAINNAME@.spv', '&&']
-	message('Info: spirv-opt has NOT --canonicalize-ids (glslang < 16.0) so use spirv-remap instead.')
-	spirv_remap = find_program('spirv-remap')
-	spirv_remap_command = [spirv_remap, '-s', '-o', '.', '-i', '@PLAINNAME@.spv', '&&']
+    spirv_opt_args = [] # MoltenVK spirv-cross has a bug that breaks optimized shaders
+else
+    if not has_canonicalize_ids_spirv_opt
+        error('spirv-opt does not support --canonicalize-ids, a newer Vulkan SDK is required')
+    endif
+    spirv_opt_args = ['-Os', '--canonicalize-ids', '--strip-debug']
 endif
 
-bintoc_command = [bintoc, '@PLAINNAME@.spv', '@PLAINNAME@_spv', '@OUTPUT@']
+glslang_args = ['-V', '--quiet']
+if get_option('buildtype').startswith('debug')
+    glslang_args += '-g'
+endif
 
 vq_pak_path = join_paths(meson.project_source_root(), 'Misc', 'vq_pak')
 mkpak_toc_file = join_paths(vq_pak_path, 'vq_pak_contents.txt')
@@ -91,20 +113,6 @@ run_generate_embedded_pak = custom_target('run-embed_vkquake_pak',
 							output : 'embedded_pak.c',
 							input : run_mkpak,
 							command : bintoc_compress_command)
-shaders_c = []
-foreach shader : shaders
-    target_env = shader.contains('sops') ? ['--target-env', 'vulkan1.1'] : []
-    debug_flag = get_option('buildtype').startswith('debug') ? ['-g'] : []
-    glslang_command = [glslang, '-V', '--quiet'] + debug_flag + target_env + ['-o', '@PLAINNAME@.spv', '@INPUT@', '--depfile', '@PLAINNAME@.deps', '&&']
-    shaders_c += custom_target(shader.underscorify(),
-                 input: shader,
-                 output: '@PLAINNAME@.c',
-                 depfile: '@PLAINNAME@.deps',
-                 command: glslang_command
-                          + spirv_opt_command
-                          + spirv_remap_command
-                          + bintoc_command)
-endforeach
 
 # shader sources compiled multiple times with different preprocessor defines
 shader_variants = [
@@ -148,27 +156,43 @@ shader_variants = [
     ['Shaders/update_lightmap.comp', 'update_lightmap_10bit_rt.comp', ['-DUSE_10BIT=1', '-DRAY_QUERIES=1']],
 ]
 
+fs = import('fs')
+
+shader_jobs = []
+foreach shader : shaders
+    target_env = shader.contains('sops') ? ['--target-env', 'vulkan1.1'] : []
+    shader_jobs += [[shader, fs.name(shader), target_env]]
+endforeach
 foreach variant : shader_variants
-    variant_source = variant[0]
-    variant_output = variant[1]
-    variant_defines = variant[2]
-    debug_flag = get_option('buildtype').startswith('debug') ? ['-g'] : []
-    variant_command = [glslang, '-V', '--quiet'] + debug_flag + variant_defines + ['-o', variant_output + '.spv', '@INPUT@', '--depfile', variant_output + '.deps', '&&']
-    if spirv_opt_command.length() > 0
-        variant_command += [spirv_opt, '-Os']
-        if has_canonicalize_ids_spirv_opt
-            variant_command += ['--canonicalize-ids', '--strip-debug']
-        endif
-        variant_command += [variant_output + '.spv', '-o', variant_output + '.spv', '&&']
+    shader_jobs += [[variant[0], variant[1], variant[2]]]
+endforeach
+
+shaders_c = []
+foreach job : shader_jobs
+    source = job[0]
+    name = job[1]
+    args = glslang_args + job[2]
+    if spirv_opt_args.length() > 0
+        spv = custom_target(name.underscorify() + '_raw_spv',
+            input : source,
+            output : name + '.raw.spv',
+            depfile : name + '.deps',
+            command : [glslang] + args + ['-o', '@OUTPUT@', '@INPUT@', '--depfile', '@DEPFILE@'])
+        spv = custom_target(name.underscorify() + '_spv',
+            input : spv,
+            output : name + '.spv',
+            command : [spirv_opt] + spirv_opt_args + ['@INPUT@', '-o', '@OUTPUT@'])
+    else
+        spv = custom_target(name.underscorify() + '_spv',
+            input : source,
+            output : name + '.spv',
+            depfile : name + '.deps',
+            command : [glslang] + args + ['-o', '@OUTPUT@', '@INPUT@', '--depfile', '@DEPFILE@'])
     endif
-    if spirv_remap_command.length() > 0
-        variant_command += [spirv_remap, '-s', '-o', '.', '-i', variant_output + '.spv', '&&']
-    endif
-    shaders_c += custom_target(variant_output.underscorify(),
-                 input: variant_source,
-                 output: variant_output + '.c',
-                 depfile: variant_output + '.deps',
-                 command: variant_command + [bintoc, variant_output + '.spv', variant_output + '_spv', '@OUTPUT@'])
+    shaders_c += custom_target(name.underscorify() + '_c',
+        input : spv,
+        output : name + '.c',
+        command : [bintoc, '@INPUT@', name + '_spv', '@OUTPUT@'])
 endforeach
 
 srcs = [
@@ -213,13 +237,10 @@ srcs = [
     'Quake/mdfour.c',
     'Quake/mem.c',
     'Quake/menu.c',
-    'Quake/net_bsd.c',
     'Quake/net_dgrm.c',
     'Quake/net_loop.c',
     'Quake/net_main.c',
-    'Quake/net_udp.c',
     'Quake/palette.c',
-    'Quake/pl_linux.c',
     'Quake/pr_cmds.c',
     'Quake/pr_edict.c',
     'Quake/pr_exec.c',
@@ -247,7 +268,6 @@ srcs = [
     'Quake/sv_phys.c',
     'Quake/sv_user.c',
 	'Quake/sys_sdl.c',
-    'Quake/sys_sdl_unix.c',
     'Quake/tasks.c',
     'Quake/view.c',
     'Quake/wad.c',
@@ -256,7 +276,36 @@ srcs = [
 	 run_generate_embedded_pak,
 ]
 
-cflags = ['-Wall', '-Wno-trigraphs', '-Werror', '-std=gnu11', '-D_FILE_OFFSET_BITS=64']
+if host_machine.system() == 'windows'
+    srcs += [
+        'Quake/net_win.c',
+        'Quake/net_wins.c',
+        'Quake/net_wipx.c',
+        'Quake/pl_win.c',
+        'Quake/sys_sdl_win.c',
+    ]
+    srcs += import('windows').compile_resources(
+        'Windows/vkQuake.rc',
+        # the \xA9 copyright escape is Windows-1252; llvm-rc refuses 8 bit
+        # codepoints without an explicit codepage. gcc builds use windres,
+        # which takes no /C option
+        args : cc.get_id() == 'gcc' ? [] : ['/C', '1252'],
+        include_directories : include_directories('Windows', 'Quake'),
+        depend_files : ['Windows/vkQuake.ico'])
+else
+    srcs += [
+        'Quake/net_bsd.c',
+        'Quake/net_udp.c',
+        'Quake/pl_linux.c',
+        'Quake/sys_sdl_unix.c',
+    ]
+endif
+
+cflags = cc.get_supported_arguments('-Wno-trigraphs', '-Wno-microsoft-enum-forward-reference') + ['-D_FILE_OFFSET_BITS=64']
+if cc.get_id() == 'clang'
+    # the stb single header libraries define their whole API static
+    cflags += '-Wno-unused-function'
+endif
 
 deps = [
     cc.find_library('m', required : false),
@@ -264,6 +313,13 @@ deps = [
     dependency('threads'),
     sdl_dep,
 ]
+
+if host_machine.system() == 'windows'
+    foreach syslib : ['ws2_32', 'winmm', 'dbghelp']
+        deps += cc.find_library(syslib)
+    endforeach
+    import('fs').copyfile('Windows/SDL3/lib64/SDL3.dll')
+endif
 
 if build_machine.system() == 'darwin'
     molten_dirs = []
@@ -279,49 +335,88 @@ if get_option('use_codec_wave').enabled()
     cflags += '-DUSE_CODEC_WAVE'
 endif
 
+if host_machine.system() == 'windows'
+    # the bundled codec libraries, like the other Windows builds use
+    codec_inc = include_directories('Windows/codecs/include')
+    codec_lib_dir = meson.project_source_root() / 'Windows/codecs/x64'
+    codec_deps = {}
+    foreach name, option : {
+        'libmad' : 'use_codec_mp3',
+        'libmpg123' : 'use_codec_mp3',
+        'libFLAC' : 'use_codec_flac',
+        'libogg' : 'use_codec_vorbis',
+        'libvorbisfile' : 'use_codec_vorbis',
+        'libvorbis' : 'use_codec_vorbis',
+        'libopus' : 'use_codec_opus',
+        'libopusfile' : 'use_codec_opus',
+    }
+        lib = cc.find_library(name, dirs : codec_lib_dir, required : get_option(option))
+        codec_deps += {name : lib.found() ? declare_dependency(include_directories : codec_inc, dependencies : lib) : lib}
+    endforeach
+    foreach dll : ['libFLAC-8.dll', 'libmad-0.dll', 'libmpg123-0.dll', 'libogg-0.dll', 'libopus-0.dll', 'libopusfile-0.dll', 'libvorbis-0.dll', 'libvorbisfile-3.dll']
+        import('fs').copyfile('Windows/codecs/x64' / dll)
+    endforeach
+    mad_dep = codec_deps['libmad']
+    mpg123_dep = codec_deps['libmpg123']
+    flac_dep = codec_deps['libFLAC']
+    ogg_dep = codec_deps['libogg']
+    vorbisfile_dep = codec_deps['libvorbisfile']
+    vorbis_dep = codec_deps['libvorbis']
+    tremor_dep = dependency('', required : false)
+    opus_dep = codec_deps['libopus']
+    opusfile_dep = codec_deps['libopusfile']
+else
+    if get_option('mp3_lib') == 'mad'
+        mad_dep = dependency('mad', required : get_option('use_codec_mp3'))
+    else
+        mpg123_dep = dependency('libmpg123', required : get_option('use_codec_mp3'))
+    endif
+    flac_dep = dependency('flac', required : get_option('use_codec_flac'))
+    ogg_dep = dependency('ogg', required : get_option('use_codec_vorbis'))
+    if get_option('vorbis_lib') == 'vorbis'
+        vorbisfile_dep = dependency('vorbisfile', required : get_option('use_codec_vorbis'))
+        vorbis_dep = dependency('vorbis', required : get_option('use_codec_vorbis'))
+    else
+        tremor_dep = dependency('vorbisidec', required : get_option('use_codec_vorbis'))
+    endif
+    opus_dep = dependency('opus', required : get_option('use_codec_opus'))
+    opusfile_dep = dependency('opusfile', required : get_option('use_codec_opus'))
+endif
+
 if get_option('mp3_lib') == 'mad'
-    mp3_dep = dependency('mad', required : get_option('use_codec_mp3'))
-    if mp3_dep.found()
+    if mad_dep.found()
         srcs += [ 'Quake/snd_mp3.c', 'Quake/snd_mp3tag.c' ]
-        deps += mp3_dep
+        deps += mad_dep
         cflags += '-DUSE_CODEC_MP3'
     endif
 else
-    mp3_dep = dependency('libmpg123', required : get_option('use_codec_mp3'))
-    if mp3_dep.found()
+    if mpg123_dep.found()
         srcs += [ 'Quake/snd_mpg123.c', 'Quake/snd_mp3tag.c' ]
-        deps += mp3_dep
+        deps += mpg123_dep
         cflags += '-DUSE_CODEC_MP3'
     endif
 endif
 
-flac_dep = dependency('flac', required : get_option('use_codec_flac'))
 if flac_dep.found()
     srcs += 'Quake/snd_flac.c'
     deps += flac_dep
     cflags += '-DUSE_CODEC_FLAC'
 endif
 
-ogg_dep = dependency('ogg', required : get_option('use_codec_vorbis'))
 if get_option('vorbis_lib') == 'vorbis'
-    vorbisfile_dep = dependency('vorbisfile', required : get_option('use_codec_vorbis'))
-    vorbis_dep = dependency('vorbis', required : get_option('use_codec_vorbis'))
     if ogg_dep.found() and vorbisfile_dep.found() and vorbis_dep.found()
         srcs += 'Quake/snd_vorbis.c'
         deps += [ ogg_dep, vorbisfile_dep, vorbis_dep ]
         cflags += '-DUSE_CODEC_VORBIS'
     endif
 else
-    vorbis_dep = dependency('vorbisidec', required : get_option('use_codec_vorbis'))
-    if ogg_dep.found() and vorbis_dep.found()
+    if ogg_dep.found() and tremor_dep.found()
         srcs += 'Quake/snd_vorbis.c'
-        deps += [ ogg_dep, vorbis_dep ]
+        deps += [ ogg_dep, tremor_dep ]
         cflags += [ '-DUSE_CODEC_VORBIS', '-DVORBIS_USE_TREMOR' ]
     endif
 endif
 
-opus_dep = dependency('opus', required : get_option('use_codec_opus'))
-opusfile_dep = dependency('opusfile', required : get_option('use_codec_opus'))
 if opus_dep.found() and opusfile_dep.found()
     srcs += 'Quake/snd_opus.c'
     deps += [ opus_dep, opusfile_dep ]
@@ -340,4 +435,11 @@ incdirs = [
     'Quake/mimalloc',
 ]
 
-executable('vkquake', [srcs, shaders_c], dependencies : deps, include_directories : incdirs, c_args : cflags, c_pch: ['Quake/quakedef.h', 'Quake/quakedef.c'])
+executable(
+    'vkquake',
+    [srcs, shaders_c],
+    dependencies : deps,
+    include_directories : incdirs,
+    c_args : cflags,
+    c_pch : 'Quake/quakedef.h',
+    win_subsystem : 'windows')

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,15 @@ make -f Makefile.w64a
 
 If you are on Linux and want to cross-compile for Windows, see the `build_cross_win??.sh` scripts.
 
+#### Meson
+
+With [Meson](https://mesonbuild.com/), [Ninja](https://ninja-build.org/) and a compiler installed (LLVM/Clang on PATH, or run `meson setup --vsenv build` for MSVC):
+
+~~~
+cd vkQuake
+meson setup build && ninja -C build
+~~~
+
 ### Linux
 
 Make sure that both your GPU and your GPU driver support [Vulkan](https://en.wikipedia.org/wiki/Vulkan#Support_across_vendors).
@@ -160,7 +169,7 @@ meson build -Ddebug=true -Dstrip=false && ninja -C build
 Meson prefers SDL3 and falls back to SDL2 if it is not installed; add `-Duse_sdl3=disabled` to force SDL2 (or `enabled` to require SDL3).
 
 > **Note**\
-> The Meson version needs to be 0.47.0 or newer. For older distributions you can use make:
+> The Meson version needs to be 1.3.0 or newer. For older distributions you can use make:
 > ~~~
 > cd vkQuake/Quake
 > make -j
@@ -168,7 +177,7 @@ Meson prefers SDL3 and falls back to SDL2 if it is not installed; add `-Duse_sdl
 > Meson is the preferred way to build vkQuake because it automatically checks for out of date file depenencies, is faster and has better error reporting for missing dependencies.
 
 > **Note**\
-> vkQuake 0.97 and later requires at least **SDL2 2.0.6 with enabled Vulkan support**. The precompiled versions in some of the distribution repositories (e.g. Ubuntu) do not currently ship with Vulkan support. You will therefore need to compile it from source. Make sure you have libvulkan-dev installed before running configure.
+> vkQuake requires **SDL3** or, as a fallback for older distributions, at least **SDL2 2.0.6 with enabled Vulkan support**.
 
 ### MacOS
 
@@ -194,7 +203,7 @@ meson build -Ddebug=true -Dstrip=false && ninja -C build
 Meson prefers SDL3 and falls back to SDL2 if it is not installed; add `-Duse_sdl3=disabled` to force SDL2 (or `enabled` to require SDL3).
 
 > **Note**\
-> The Meson version needs to be 0.47.0 or newer.
+> The Meson version needs to be 1.3.0 or newer.
 
 ## Error reporting
 


### PR DESCRIPTION
Windows builds work with any toolchain meson finds (LLVM clang from PATH, or MSVC via 'meson setup --vsenv'): platform system sources, the version resource, windows subsystem, the bundled SDL3 and codec libraries with their DLLs copied next to the executable.

- Toolchain-agnostic flags: warning_level/werror/c_std builtins instead of hardcoded GCC-style arguments, with c_std falling back gnu11 -> c11 for MSVC (raises the required meson to 1.3) and probed arguments for the rest. werror now also covers the native tools, so mkpak checks its fread result and refuses pak entry names that would have been silently truncated before.
- The shader pipeline is one custom target per tool instead of '&&' chained commands, which only worked because ninja runs commands through a POSIX shell on Linux; on Windows the whole chain ended up in glslangValidator's argv. The spirv-remap fallback for old SPIRV-Tools is gone; spirv-opt must support --canonicalize-ids (checked at configure time).
- The version resource is compiled with an explicit /C 1252 codepage under llvm-rc and rc.exe; llvm-rc refuses the \xA9 copyright escape without it (windres takes no /C and needs nothing).
- The AppImage image moves to Ubuntu 22.04, raising the glibc floor to 2.35; older distributions can compile from source. The Vulkan SDK comes from the LunarG tarball archive instead of the discontinued apt packages (the May 2025 SDK was the last apt release), with only the shader tools, headers and loader extracted; glslangValidator is a symlink to glslang, so both are needed. SDL2 for the fallback compile check comes from apt, dependency versions are ARGs.
- Build documentation updated accordingly.