### PR TITLE
readme: Improve FreeBSD instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ $ pkg_add vkquake
 
 ### FreeBSD
 
-[FreeBSD](https://freebsd.org) includes vkQuake in the standard port/package repoistories since version [11.3](https://www.freebsd.org/releases/11.3R/announce).
+[FreeBSD](https://freebsd.org) includes vkQuake in the ports collection since version [11.3](https://www.freebsd.org/releases/11.3R/announce).
 
 If you're running `FreeBSD 11.3` or greater, you can install the package with:
 
@@ -59,10 +59,15 @@ If you're running `FreeBSD 11.3` or greater, you can install the package with:
 # pkg install vkquake
 ```
 
-Alternatvely, you can build vkQuake with FreeBSD's port collection:
+Alternatvely, you can build vkQuake using the ports framework:
 ```console
 $ cd /usr/ports/games/vkquake
 # make install
+```
+
+Place game assets in `/usr/local/share/quake/` where they will be detected automatically:
+```console
+$ cd ~/Downloads/; cp id1 hipnotic mg1 rogue ctf /usr/local/share/quake/
 ```
 
 ### Quake '2021 re-release'


### PR DESCRIPTION
This is not ready yet. We still need to clarify how `rerelase/` works?

If I copy the files from $steamquakedir/rerelease to `/usr/local/share/quake`, then everything seems to work great except messages that appear on the screen are placeholder vars instead of the real text, such as `$MAP_SKILL_NORMAL` when trying to enter the base game on normal difficulty.

If I don't do that and instead copy the directories as they appear in steam (i.e., rerelease files in the `rerelease/` folder), we have no music and the steam bundled mods do not show up.

Fixes: https://github.com/Novum/vkQuake/issues/914

My tree that is the most working looks like this:
```
$ tree /usr/local/share/quake/
/usr/local/share/quake/
├── ctf
│   ├── pak0.pak
│   └── vkQuake.cfg
├── dopa
│   ├── pak0.pak
│   └── vkQuake.cfg
├── hipnotic
│   └── pak0.pak
├── id1
│   ├── config.cfg
│   ├── glquake
│   │   ├── 15to8.pal
│   │   ├── (omitted many files for some semblance brevity)
│   │   └── zombie.ms2
│   ├── maps
│   │   ├── 100m.bsp
│   │   ├── 150dm3.bsp
│   │   ├── (omitted many files for some semblance brevity)
│   │   ├── zxcdm1.bsp
│   │   └── zzzzz.bsp
│   ├── music
│   │   ├── track02.ogg
│   │   ├── track03.ogg
│   │   ├── track04.ogg
│   │   ├── track05.ogg
│   │   ├── track06.ogg
│   │   ├── track07.ogg
│   │   ├── track08.ogg
│   │   ├── track09.ogg
│   │   ├── track10.ogg
│   │   └── track11.ogg
│   ├── pak0.pak
│   └── pak1.pak
├── mg1
│   ├── pak0.pak
│   └── vkQuake.cfg
├── qw
│   ├── qwprogs.dat
│   └── skins
│       ├── 311.pcx
│       ├── 311.txt
│       ├── (omitted many files for some semblance of brevity)
│       └── wolfpak.txt
├── rerelease
│   ├── ctf
│   │   └── pak0.pak
│   ├── dopa
│   │   └── pak0.pak
│   ├── hipnotic
│   │   ├── music
│   │   │   ├── track02.ogg
│   │   │   ├── track03.ogg
│   │   │   ├── track04.ogg
│   │   │   ├── track05.ogg
│   │   │   ├── track06.ogg
│   │   │   ├── track07.ogg
│   │   │   ├── track08.ogg
│   │   │   └── track09.ogg
│   │   └── pak0.pak
│   ├── id1
│   │   ├── music
│   │   │   ├── track02.ogg
│   │   │   ├── track03.ogg
│   │   │   ├── track04.ogg
│   │   │   ├── track05.ogg
│   │   │   ├── track06.ogg
│   │   │   ├── track07.ogg
│   │   │   ├── track08.ogg
│   │   │   ├── track09.ogg
│   │   │   ├── track10.ogg
│   │   │   └── track11.ogg
│   │   └── pak0.pak
│   ├── mg1
│   │   └── pak0.pak
│   └── rogue
│       ├── music
│       │   ├── track02.ogg
│       │   ├── track03.ogg
│       │   ├── track04.ogg
│       │   ├── track05.ogg
│       │   ├── track06.ogg
│       │   ├── track07.ogg
│       │   ├── track08.ogg
│       │   └── track09.ogg
│       └── pak0.pak
├── rogue
│   └── pak0.pak
└── vkquake.pak

22 directories, 1089 files
```
Any mods I put in there are detected automatically and appear to work, but what about music files? Should they be duplicated both places? Is this almost entirely wrong?