### PR TITLE
add platform optimization support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2541,55 +2541,22 @@ Mod_LoadMarksurfaces
 */
 static void Mod_LoadMarksurfaces (qmodel_t *mod, byte *mod_base, lump_t *l, int bsp2)
 {
-	int	 i, j, count;
-	int *out;
-	if (bsp2)
-	{
-		byte *in = mod_base + l->fileofs;
+	int		i, count;
+	void *in = mod_base + l->fileofs;
 
-		if (l->filelen % sizeof (unsigned int))
-			Host_Error ("Mod_LoadMarksurfaces: funny lump size in %s", mod->name);
+	if(l->filelen % (bsp2 ? sizeof(uint32_t) : sizeof(int16_t)))
+		Host_Error ("Mod_LoadMarksurfaces: funny lump size in %s",mod->name);
 
-		count = l->filelen / sizeof (unsigned int);
-		out = (int *)Mem_Alloc (count * sizeof (*out));
+	count = l->filelen / (bsp2 ? sizeof(uint32_t) : sizeof(int16_t));
+	mod->marksurfaces = (int*)Mem_Alloc (count * sizeof(int));
+	mod->nummarksurfaces = count;
 
-		mod->marksurfaces = out;
-		mod->nummarksurfaces = count;
+	if (count > 32767)
+		Con_DWarning ("%i marksurfaces exceeds standard limit of 32767.\n", count);
 
-		for (i = 0; i < count; i++)
-		{
-			j = ReadLongUnaligned (in + (i * sizeof (int)));
-			if (j >= mod->numsurfaces)
-				Host_Error ("Mod_LoadMarksurfaces: bad surface number");
-			out[i] = j;
-		}
-	}
-	else
-	{
-		byte *in = mod_base + l->fileofs;
-
-		if (l->filelen % sizeof (short))
-			Host_Error ("Mod_LoadMarksurfaces: funny lump size in %s", mod->name);
-
-		count = l->filelen / sizeof (short);
-		out = (int *)Mem_Alloc (count * sizeof (*out));
-
-		mod->marksurfaces = out;
-		mod->nummarksurfaces = count;
-
-		// johnfitz -- warn mappers about exceeding old limits
-		if (count > 32767)
-			Con_DWarning ("%i marksurfaces exceeds standard limit of 32767.\n", count);
-		// johnfitz
-
-		for (i = 0; i < count; i++)
-		{
-			j = (unsigned short)ReadShortUnaligned (in + (i * sizeof (short))); // johnfitz -- explicit cast as unsigned short
-			if (j >= mod->numsurfaces)
-				Sys_Error ("Mod_LoadMarksurfaces: bad surface number");
-			out[i] = j;
-		}
-	}
+	for (i=0 ; i<count ; i++)
+		if((mod->marksurfaces[i] = bsp2 ? le32toh(((uint32_t*)in)[i]) : le16toh(((int16_t*)in)[i])) >= mod->numsurfaces)
+			Sys_Error ("Mod_LoadMarksurfaces: bad surface number");
 }
 
 /*
@@ -4248,34 +4215,40 @@ static double MD5_ParseFloat (const void **buffer)
 md5vertinfo_s
 ================
 */
+#pragma pack(push,1)
 typedef struct md5vertinfo_s
 {
 	size_t		 firstweight;
 	unsigned int count;
 } md5vertinfo_t;
+#pragma pack(pop)
 
 /*
 ================
 md5weightinfo_s
 ================
 */
+#pragma pack(push,1)
 typedef struct md5weightinfo_s
 {
 	size_t joint_index;
 	vec4_t pos;
 } md5weightinfo_t;
+#pragma pack(pop)
 
 /*
 ================
 jointinfo_s
 ================
 */
+#pragma pack(push,1)
 typedef struct jointinfo_s
 {
 	ssize_t		parent; //-1 for a root joint
 	char		name[32];
 	jointpose_t inverse;
 } jointinfo_t;
+#pragma pack(pop)
 
 /*
 ================

--- a/meson.build
+++ b/meson.build
@@ -2,12 +2,55 @@ project(
     'vkquake',
     'c',
     meson_version : '>= 1.3',
-    default_options : ['c_std=gnu11,c11', 'buildtype=release', 'strip=false', 'debug=true', 'b_ndebug=if-release', 'warning_level=1', 'werror=true'])
+    default_options : ['c_std=gnu2x,c2x', 'buildtype=release', 'strip=false', 'debug=true', 'b_ndebug=if-release', 'warning_level=1', 'werror=true'])
 
 cc = meson.get_compiler('c')
 
 # Always build keeping frame pointers to get better backtraces
-add_project_arguments(cc.get_supported_arguments('-fno-omit-frame-pointer', '/Oy-'), language: 'c')
+if cc.get_argument_syntax() == 'msvc'
+add_project_arguments(cc.get_supported_arguments('/Oy-'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('/Gv'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('/std:clatest'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('/Zc:__STDC__'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('/Zc:preprocessor'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('/openmp:experimental'), language: 'c')
+else
+add_project_arguments(cc.get_supported_arguments('-march=native'), language: 'c', native: true)
+
+if target_machine.cpu_family() == 'x86_64'
+    message('SSE floating-point math is supported')
+    add_project_arguments(cc.get_supported_arguments('-mfpmath=sse'), language: 'c')
+elif target_machine.cpu_family() == 'ppc' or target_machine.cpu_family() == 'ppc64'
+  if cc.has_header('altivec.h')
+    # Test if the compiler can actually compile Altivec code
+    altivec_test = '''
+      #include <altivec.h>
+      int main() {
+        vector unsigned char v1 = vec_splat_u8(1);
+        return 0;
+      }
+    '''
+    if cc.compiles(altivec_test, name : 'AltiVec support')
+      message('AltiVec is supported')
+      add_project_arguments('-maltivec', language : 'c')
+    endif
+  endif
+endif
+
+add_project_arguments(cc.get_supported_arguments('-fno-omit-frame-pointer'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('-ftree-vectorize'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('-fopenmp', '-fopenmp-simd'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('-fno-asynchronous-unwind-tables'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('-ffunction-sections'), language: 'c')
+add_project_arguments(cc.get_supported_arguments('-fdata-sections'), language: 'c')
+
+cflags = cc.get_supported_arguments('-Wno-trigraphs', '-Wno-microsoft-enum-forward-reference') + ['-D_FILE_OFFSET_BITS=64']
+if cc.get_id() == 'clang'
+    # the stb single header libraries define their whole API static
+    cflags += '-Wno-unused-function'
+    cflags += '-Wno-gnu-alignof-expression'
+endif
+endif
 
 if host_machine.system() == 'windows'
     foreach native : [true, false]
@@ -299,12 +342,6 @@ else
         'Quake/pl_linux.c',
         'Quake/sys_sdl_unix.c',
     ]
-endif
-
-cflags = cc.get_supported_arguments('-Wno-trigraphs', '-Wno-microsoft-enum-forward-reference') + ['-D_FILE_OFFSET_BITS=64']
-if cc.get_id() == 'clang'
-    # the stb single header libraries define their whole API static
-    cflags += '-Wno-unused-function'
 endif
 
 deps = [


### PR DESCRIPTION
meson build now supports:
- tree vectorize
- MSVC vectorcall
- OpenMP
- use SSE for x86_64 target
- use AltiVec for ppc or ppc64 target
- standard c2x supporting old compiler tags and incomplete MSVC /std:clatest feature set