### PR TITLE
Fix entity lerp jitter at host_maxfps above 72

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -509,7 +509,7 @@ static qboolean CL_LerpEntity (entity_t *ent, vec3_t org, vec3_t ang, float frac
 		a = f;
 
 		// johnfitz -- don't cl_lerp entities that will be r_lerped
-		if (r_lerpmove.value && (ent->lerpflags & LERP_MOVESTEP))
+		if (r_lerpmove.value && ent->lerp.movestep)
 		{
 			f = 1;
 
@@ -652,6 +652,7 @@ void CL_RelinkEntities (void)
 	dlight_t *dl;
 	float	  frametime;
 	int		  modelflags;
+	qboolean  teleported;
 
 	// determine partial update time
 	frac = CL_LerpPoint ();
@@ -714,18 +715,24 @@ void CL_RelinkEntities (void)
 		{
 			ent->model = NULL;
 			R_FreeEntityBLAS (ent);
-			ent->lerpflags |= LERP_RESETMOVE | LERP_RESETANIM; // johnfitz -- next time this entity slot is reused, the lerp will need to be reset
 			InvalidateTraceLineCache ();
 			continue;
 		}
 
 		VectorCopy (ent->origin, oldorg);
 
-		if (CL_LerpEntity (ent, ent->origin, ent->angles, frac))
-			ent->lerpflags |= LERP_RESETMOVE;
+		teleported = CL_LerpEntity (ent, ent->origin, ent->angles, frac);
 
 		if (cl.time < cl.oldtime)
-			ent->lerpflags |= LERP_RESETMOVE | LERP_RESETANIM;
+		{
+			// time ran backwards (demo jump): show current state without lerping
+			ent->lerp.prev_frame = ent->frame;
+			ent->lerp.frame_change_time = 0;
+			ent->lerp.snap_frames = 0;
+			VectorCopy (ent->msg_origins[0], ent->lerp.prev_origin);
+			VectorCopy (ent->msg_angles[0], ent->lerp.prev_angles);
+			ent->lerp.move_change_time = 0;
+		}
 
 		if (ent->netstate.tagentity)
 			if (!CL_AttachEntity (ent, frac))
@@ -737,7 +744,7 @@ void CL_RelinkEntities (void)
 		modelflags = (ent->effects >> 24) & 0xff;
 		modelflags |= ent->model->flags;
 
-		if (ent->forcelink || ent->lerpflags & LERP_RESETMOVE)
+		if (ent->forcelink || teleported)
 			CL_ResetTrail (ent);
 
 		// rotate binary objects locally
@@ -761,13 +768,32 @@ void CL_RelinkEntities (void)
 			dl->minlight = 32;
 			dl->die = cl.time + 0.1;
 
-			// johnfitz -- assume muzzle flash accompanied by muzzle flare, which looks bad when lerped
+			// johnfitz -- assume muzzle flash accompanied by muzzle flare, which looks bad when lerped:
+			// snap the transition into the flash frame and the one out of it
 			if (r_lerpmodels.value != 2)
 			{
 				if (ent == &cl.entities[cl.viewentity])
-					cl.viewent.lerpflags |= LERP_RESETANIM | LERP_RESETANIM2; // no lerping for two frames
+				{
+					// viewent frame changes are detected later in V_CalcRefdef, so the
+					// transitions into and out of the flash frame both consume the counter.
+					// effects keeps the flash bit until the next update overwrites it and
+					// relink runs per render frame, so arm only once per server update
+					if (cl.viewent.lerp.snap_msgtime != ent->msgtime)
+					{
+						cl.viewent.lerp.prev_frame = cl.viewent.frame;
+						cl.viewent.lerp.frame_change_time = 0;
+						cl.viewent.lerp.snap_frames = 2;
+						cl.viewent.lerp.snap_msgtime = ent->msgtime;
+					}
+				}
 				else
-					ent->lerpflags |= LERP_RESETANIM | LERP_RESETANIM2; // no lerping for two frames
+				{
+					// the flash frame arrived in the same packet and was already recorded
+					// at parse; snap it retroactively, the counter covers the change out
+					ent->lerp.prev_frame = ent->frame;
+					ent->lerp.frame_change_time = 0;
+					ent->lerp.snap_frames = 1;
+				}
 			}
 			// johnfitz
 		}
@@ -902,26 +928,10 @@ void CL_RelinkEntities (void)
 			R_AllocateEntityBLAS (ent);
 			cl_visedicts[cl_numvisedicts] = ent;
 			cl_numvisedicts++;
-			// Update animation state for alias models
-			if (ent->model && ent->model->type == mod_alias)
-			{
-				aliashdr_t *hdr = (aliashdr_t *)Mod_Extradata (ent->model);
-				if (hdr)
-					R_UpdateEntityAnimState (ent, hdr);
-				R_UpdateEntityMoveState (ent);
-			}
 		}
 	}
 
 	R_UpdateEntityDlights (); // 2021 rerelease shadow casting light entities
-
-	// johnfitz -- lerping
-	// ericw -- this was done before the upper 8 bits of cl.stats[STAT_WEAPON] were filled in, breaking on large maps like zendar.bsp
-	if (cl.viewent.model != cl.model_precache[cl.stats[STAT_WEAPON]])
-	{
-		cl.viewent.lerpflags |= LERP_RESETANIM; // don't lerp animation across model changes
-	}
-	// johnfitz
 }
 
 #ifdef PSET_SCRIPT

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -116,7 +116,6 @@ entity_t *CL_EntityNum (int num)
 		while (cl.num_entities <= num)
 		{
 			cl.entities[cl.num_entities].baseline = nullentitystate;
-			cl.entities[cl.num_entities].lerpflags |= LERP_RESETMOVE | LERP_RESETANIM; // johnfitz
 			cl.num_entities++;
 		}
 	}
@@ -451,20 +450,91 @@ static void CLFTE_ParseBaseline (entity_state_t *es)
 	CLFTE_ReadDelta (0, es, &nullentitystate, &nullentitystate);
 }
 
+/*
+==================
+CL_EntityLerpUpdated
+
+Single point where entity interpolation state advances. Called by both
+protocol paths once the entity's frame and msg_origins/msg_angles hold the
+values from the current message. The renderer only reads this state.
+
+snap_anim: this update must not be animation-lerped (new/reused entity slot,
+missed thinks).
+==================
+*/
+static void CL_EntityLerpUpdated (entity_t *ent, int oldframe, qboolean forcelink, qboolean snap_anim)
+{
+	int j;
+
+	// the finish hint sent with this update belongs to changes recorded from this
+	// update; the duration is frozen here so later hints can't stretch it
+	double duration = (ent->lerp.frame_finish_time > cl.mtime[0]) ? ent->lerp.frame_finish_time - cl.mtime[0] : 0.1;
+
+	if (ent->frame != oldframe || forcelink || snap_anim)
+	{
+		if (forcelink || snap_anim)
+		{
+			ent->lerp.prev_frame = ent->frame;
+			ent->lerp.frame_change_time = 0;
+			if (forcelink)
+				ent->lerp.snap_frames = 0; // don't inherit a pending muzzleflash snap from a previous occupant of this slot
+		}
+		else if (ent->lerp.snap_frames > 0)
+		{
+			ent->lerp.snap_frames--;
+			ent->lerp.prev_frame = ent->frame;
+			ent->lerp.frame_change_time = cl.mtime[0];
+		}
+		else
+		{
+			ent->lerp.prev_frame = oldframe;
+			ent->lerp.frame_change_time = cl.mtime[0];
+		}
+		ent->lerp.frame_duration = duration;
+	}
+
+	if (!VectorCompare (ent->msg_origins[0], ent->msg_origins[1]) || !VectorCompare (ent->msg_angles[0], ent->msg_angles[1]))
+	{
+		qboolean teleport = false;
+		for (j = 0; j < 3; j++)
+			if (fabs (ent->msg_origins[0][j] - ent->msg_origins[1][j]) > 100)
+				teleport = true; // johnfitz -- don't lerp teleports
+
+		if (forcelink || teleport)
+		{
+			VectorCopy (ent->msg_origins[0], ent->lerp.prev_origin);
+			VectorCopy (ent->msg_angles[0], ent->lerp.prev_angles);
+			ent->lerp.move_change_time = 0;
+		}
+		else
+		{
+			VectorCopy (ent->msg_origins[1], ent->lerp.prev_origin);
+			VectorCopy (ent->msg_angles[1], ent->lerp.prev_angles);
+			ent->lerp.move_change_time = cl.mtime[0];
+		}
+		ent->lerp.move_duration = duration;
+	}
+}
+
 // called with both fte+dp deltas
 static void CL_EntitiesDeltaed (void)
 {
 	int		  newnum;
 	qmodel_t *model;
 	qboolean  forcelink;
+	qboolean  snap_anim;
 	entity_t *ent;
 	int		  skin;
+	int		  oldframe;
 
 	for (newnum = 1; newnum < cl.num_entities; newnum++)
 	{
 		ent = CL_EntityNum (newnum);
 		if (!ent->update_type)
 			continue; // not interested in this one
+
+		oldframe = ent->frame;
+		snap_anim = false;
 
 		if (ent->msgtime == cl.mtime[0])
 			forcelink = false; // update got fragmented, don't dirty anything.
@@ -477,7 +547,7 @@ static void CL_EntitiesDeltaed (void)
 
 			// johnfitz -- lerping
 			if (ent->msgtime + 0.2 < cl.mtime[0]) // more than 0.2 seconds since the last message (most entities think every 0.1 sec)
-				ent->lerpflags |= LERP_RESETANIM; // if we missed a think, we'd be lerping from the wrong frame
+				snap_anim = true;				  // if we missed a think, we'd be lerping from the wrong frame
 
 			ent->msgtime = cl.mtime[0];
 
@@ -498,22 +568,15 @@ static void CL_EntitiesDeltaed (void)
 		ent->effects = ent->netstate.effects;
 
 		// johnfitz -- lerping for movetype_step entities
-		if (ent->netstate.eflags & EFLAGS_STEP)
-		{
-			ent->lerpflags |= LERP_MOVESTEP;
+		ent->lerp.movestep = (ent->netstate.eflags & EFLAGS_STEP) != 0;
+		if (ent->lerp.movestep)
 			ent->forcelink = true;
-		}
-		else
-			ent->lerpflags &= ~LERP_MOVESTEP;
 
 		ent->alpha = ent->netstate.alpha;
-		ent->lerpflags &= ~LERP_FINISH;
+		ent->lerp.frame_finish_time = 0;
 #ifdef LERP_BANDAID
 		if (ent->netstate.lerp > 0)
-		{
-			ent->lerpfinish = ent->msgtime + (ent->netstate.lerp - 1) / 1000.f;
-			ent->lerpflags |= LERP_FINISH;
-		}
+			ent->lerp.frame_finish_time = ent->msgtime + (ent->netstate.lerp - 1) / 1000.f;
 #endif
 
 		model = cl.model_precache[ent->netstate.modelindex];
@@ -539,11 +602,13 @@ static void CL_EntitiesDeltaed (void)
 			if (newnum > 0 && newnum <= cl.maxclients)
 				R_TranslateNewPlayerSkin (newnum - 1); // johnfitz -- was R_TranslatePlayerSkin
 
-			ent->lerpflags |= LERP_RESETANIM; // johnfitz -- don't lerp animation across model changes
+			snap_anim = true; // johnfitz -- don't lerp animation across model changes
 		}
 		else if (model && model->synctype == ST_FRAMETIME && ent->frame != ent->netstate.frame)
 			ent->syncbase = -cl.time;
 		ent->frame = ent->netstate.frame;
+
+		CL_EntityLerpUpdated (ent, oldframe, forcelink, snap_anim);
 
 		if (forcelink)
 		{ // didn't have an update last message
@@ -632,9 +697,7 @@ static void CLFTE_ParseEntitiesUpdate (void)
 		{ // we had no previous copy of this entity...
 			ent->update_type = true;
 			CLFTE_ReadDelta (newnum, &ent->netstate, NULL, &ent->baseline);
-
-			// stupid interpolation junk.
-			ent->lerpflags |= LERP_RESETMOVE | LERP_RESETANIM;
+			ent->msgtime = 0; // the slot's stale msgtime must not defeat the forcelink check in CL_EntitiesDeltaed
 		}
 	}
 
@@ -1085,9 +1148,11 @@ static void CL_ParseUpdate (int bits)
 	qmodel_t	*model;
 	unsigned int modnum;
 	qboolean	 forcelink;
+	qboolean	 snap_anim = false;
 	entity_t	*ent;
 	int			 num;
 	int			 skin;
+	int			 oldframe;
 
 	if (cls.signon == SIGNONS - 1)
 	{ // first update is the final signon stage
@@ -1117,6 +1182,7 @@ static void CL_ParseUpdate (int bits)
 		num = MSG_ReadByte ();
 
 	ent = CL_EntityNum (num);
+	oldframe = ent->frame;
 
 	if (ent->msgtime != cl.mtime[1])
 		forcelink = true; // no previous frame to lerp from
@@ -1125,7 +1191,7 @@ static void CL_ParseUpdate (int bits)
 
 	// johnfitz -- lerping
 	if (ent->msgtime + 0.2 < cl.mtime[0]) // more than 0.2 seconds since the last message (most entities think every 0.1 sec)
-		ent->lerpflags |= LERP_RESETANIM; // if we missed a think, we'd be lerping from the wrong frame
+		snap_anim = true;				  // if we missed a think, we'd be lerping from the wrong frame
 	// johnfitz
 
 	ent->msgtime = cl.mtime[0];
@@ -1199,13 +1265,9 @@ static void CL_ParseUpdate (int bits)
 		ent->msg_angles[0][2] = ent->baseline.angles[2];
 
 	// johnfitz -- lerping for movetype_step entities
-	if (bits & U_STEP)
-	{
-		ent->lerpflags |= LERP_MOVESTEP;
+	ent->lerp.movestep = (bits & U_STEP) != 0;
+	if (ent->lerp.movestep)
 		ent->forcelink = true;
-	}
-	else
-		ent->lerpflags &= ~LERP_MOVESTEP;
 	// johnfitz
 
 	// johnfitz -- PROTOCOL_FITZQUAKE and PROTOCOL_NEHAHRA
@@ -1226,12 +1288,9 @@ static void CL_ParseUpdate (int bits)
 				Host_Error ("CL_ParseModel: bad modnum");
 		}
 		if (bits & U_LERPFINISH)
-		{
-			ent->lerpfinish = ent->msgtime + ((float)(MSG_ReadByte ()) / 255);
-			ent->lerpflags |= LERP_FINISH;
-		}
+			ent->lerp.frame_finish_time = ent->msgtime + ((float)(MSG_ReadByte ()) / 255);
 		else
-			ent->lerpflags &= ~LERP_FINISH;
+			ent->lerp.frame_finish_time = 0;
 	}
 	else if (cl.protocol == PROTOCOL_NETQUAKE)
 	{
@@ -1280,9 +1339,11 @@ static void CL_ParseUpdate (int bits)
 		if (num > 0 && num <= cl.maxclients)
 			R_TranslateNewPlayerSkin (num - 1); // johnfitz -- was R_TranslatePlayerSkin
 
-		ent->lerpflags |= LERP_RESETANIM; // johnfitz -- don't lerp animation across model changes
+		snap_anim = true; // johnfitz -- don't lerp animation across model changes
 	}
 	// johnfitz
+
+	CL_EntityLerpUpdated (ent, oldframe, forcelink, snap_anim);
 
 	if (forcelink)
 	{ // didn't have an update last message
@@ -1503,8 +1564,8 @@ static void CL_ParseStatic (int version) // johnfitz -- added a parameter
 	ent->eflags = ent->netstate.eflags; // spike -- annoying and probably not used anyway, but w/e
 
 	ent->model = cl.model_precache[ent->baseline.modelindex];
-	ent->lerpflags |= LERP_RESETANIM; // johnfitz -- lerping
 	ent->frame = ent->baseline.frame;
+	ent->lerp.prev_frame = ent->frame; // johnfitz -- lerping
 
 	ent->skinnum = ent->baseline.skin;
 	ent->effects = ent->baseline.effects;

--- a/Quake/gl_mesh.c
+++ b/Quake/gl_mesh.c
@@ -916,7 +916,7 @@ void R_UpdateAnimatedBLASes (cb_context_t *cbx)
 
 			// Get lerp data for vertex interpolation
 			lerpdata_t lerpdata;
-			R_SetupAliasFrame (e, hdr, e->frame, &lerpdata);
+			R_SetupAliasFrame (e, hdr, &lerpdata);
 			int	  pose1 = lerpdata.pose1;
 			int	  pose2 = lerpdata.pose2;
 			float blend = lerpdata.blend;

--- a/Quake/gl_refrag.c
+++ b/Quake/gl_refrag.c
@@ -252,14 +252,6 @@ void R_StoreEfrags (efrag_t **ppefrag)
 #endif
 			cl_visedicts[cl_numvisedicts++] = pent;
 			pent->visframe = r_framecount;
-			// Update animation state for alias models
-			if (pent->model && pent->model->type == mod_alias)
-			{
-				aliashdr_t *hdr = (aliashdr_t *)Mod_Extradata (pent->model);
-				if (hdr)
-					R_UpdateEntityAnimState (pent, hdr);
-				R_UpdateEntityMoveState (pent);
-			}
 		}
 		ppefrag = &pefrag->leafnext;
 	}

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -563,9 +563,7 @@ void R_DrawViewModel (cb_context_t *cbx)
 	// hack the depth range to prevent view model from poking into walls
 	GL_Viewport (cbx, r_refdef.vrect.x, glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height, 0.7f, 1.0f);
 
-	int			aliaspolys = 0;
-	aliashdr_t *paliashdr = (aliashdr_t *)Mod_Extradata (currententity->model);
-	R_UpdateEntityAnimState (currententity, paliashdr);
+	int aliaspolys = 0;
 	R_DrawAliasModel (cbx, currententity, &aliaspolys);
 	Atomic_AddUInt32 (&rs_aliaspolys, aliaspolys);
 	Atomic_IncrementUInt32 (&rs_aliaspasses);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -746,10 +746,8 @@ typedef struct
 } lerpdata_t;
 // johnfitz
 
-void R_UpdateEntityAnimState (entity_t *e, aliashdr_t *paliashdr);
-void R_UpdateEntityMoveState (entity_t *e);
-void R_GetEntityLerpedTransform (entity_t *e, vec3_t out_origin, vec3_t out_angles);
-void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, int frame, lerpdata_t *lerpdata);
+void R_GetEntityLerpedTransform (const entity_t *e, vec3_t out_origin, vec3_t out_angles);
+void R_SetupAliasFrame (const entity_t *e, aliashdr_t *paliashdr, lerpdata_t *lerpdata);
 void R_DrawAliasModel (cb_context_t *cbx, entity_t *e, int *aliaspolys);
 void R_DrawBrushModel (cb_context_t *cbx, entity_t *e, int chain, int *brushpolys, qboolean sort, qboolean water_opaque_only, qboolean water_transparent_only);
 void R_DrawSpriteModel (cb_context_t *cbx, entity_t *e);

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1023,7 +1023,7 @@ static void _Host_Frame (double time)
 				}
 				else
 				{
-					host_frametime = q_max (accumtime, host_netinterval);
+					host_frametime = host_netinterval;
 				}
 			}
 			else

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -1843,8 +1843,8 @@ static void PF_cl_makestatic (void)
 	stat->trailstate = NULL;
 	stat->emitstate = NULL;
 	stat->model = cl.model_precache[stat->baseline.modelindex];
-	stat->lerpflags |= LERP_RESETANIM; // johnfitz -- lerping
 	stat->frame = stat->baseline.frame;
+	stat->lerp.prev_frame = stat->frame; // johnfitz -- lerping
 
 	stat->skinnum = stat->baseline.skin;
 	stat->effects = stat->baseline.effects;

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -3681,6 +3681,7 @@ static void PF_copyentity (void)
 	memcpy (&dst->v, &src->v, qcvm->edict_size - sizeof (entvars_t));
 	dst->alpha = src->alpha;
 	dst->sendinterval = src->sendinterval;
+	dst->sendinterval_default = src->sendinterval_default;
 	SV_LinkEdict (dst, false);
 
 	G_INT (OFS_RETURN) = EDICT_TO_PROG (dst);

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -62,8 +62,9 @@ typedef struct edict_s
 	int			 leafnums[MAX_ENT_LEAFS];
 
 	entity_state_t baseline;
-	unsigned char  alpha;		 /* johnfitz -- hack to support alpha since it's not part of entvars_t */
-	qboolean	   sendinterval; /* johnfitz -- send time until nextthink to client for better lerp timing */
+	unsigned char  alpha;				 /* johnfitz -- hack to support alpha since it's not part of entvars_t */
+	qboolean	   sendinterval;		 /* johnfitz -- send time until nextthink to client for better lerp timing */
+	qboolean	   sendinterval_default; /* interval is the 0.1 the client assumes anyway; only sent where datagram size is unconstrained */
 	float		   oldframe;
 	float		   oldthinktime;
 	vec3_t		   predthinkpos; /* expected edict origin once its nextthink arrives (sv_smoothplatformlerps) */

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -205,95 +205,76 @@ static void GL_DrawAliasFrame (
 
 /*
 =================
-R_UpdateEntityAnimState
+R_EntityPoseAt
 
-Updates entity animation state (previouspose, currentpose, lerpstart, lerptime).
-Call once per frame when entity becomes visible, before R_SetupAliasFrame.
+Pose displayed by the given model frame at the given time (framegroup poses
+advance with time).
 =================
 */
-void R_UpdateEntityAnimState (entity_t *e, aliashdr_t *paliashdr)
+static int R_EntityPoseAt (aliashdr_t *paliashdr, int frame, double time)
 {
-	int frame = e->frame;
 	if ((frame >= paliashdr->numframes) || (frame < 0))
 		frame = 0;
 
 	int posenum = paliashdr->frames[frame].firstpose;
 	int numposes = paliashdr->frames[frame].numposes;
-
 	if (numposes > 1)
-	{
-		e->lerptime = paliashdr->frames[frame].interval;
-		posenum += (int)(cl.time / e->lerptime) % numposes;
-	}
-	else
-		e->lerptime = 0.1;
-
-	if (e->lerpflags & LERP_RESETANIM)
-	{
-		e->lerpstart = 0;
-		e->previouspose = posenum;
-		e->currentpose = posenum;
-		e->lerpflags -= LERP_RESETANIM;
-	}
-	else if (e->currentpose != posenum)
-	{
-		if (e->lerpflags & LERP_RESETANIM2)
-		{
-			e->lerpstart = 0;
-			e->previouspose = posenum;
-			e->currentpose = posenum;
-			e->lerpflags -= LERP_RESETANIM2;
-		}
-		else
-		{
-			e->lerpstart = cl.time;
-			e->previouspose = e->currentpose;
-			e->currentpose = posenum;
-		}
-	}
-
-	// Check blend==1 and snap previouspose
-	if (r_lerpmodels.value && !(e->model->flags & MOD_NOLERP && r_lerpmodels.value != 2))
-	{
-		float blend;
-		if (e->lerpflags & LERP_FINISH && numposes == 1)
-			blend = CLAMP (0, (cl.time - e->lerpstart) / (e->lerpfinish - e->lerpstart), 1);
-		else
-			blend = CLAMP (0, (cl.time - e->lerpstart) / e->lerptime, 1);
-
-		if (blend == 1.0f)
-			e->previouspose = e->currentpose;
-	}
+		posenum += (int)(time / paliashdr->frames[frame].interval) % numposes;
+	return posenum;
 }
 
 /*
 =================
 R_SetupAliasFrame -- johnfitz -- rewritten to support lerping
 
-Computes output lerp data from stable entity animation state.
-Call R_UpdateEntityAnimState first to update entity state.
+Computes pose1/pose2/blend from the parse-side interpolation state and
+cl.time. Does not modify the entity.
 =================
 */
-void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, int frame, lerpdata_t *lerpdata)
+void R_SetupAliasFrame (const entity_t *e, aliashdr_t *paliashdr, lerpdata_t *lerpdata)
 {
+	int frame = e->frame;
 	if ((frame >= paliashdr->numframes) || (frame < 0))
 		frame = 0;
 
-	int posenum = paliashdr->frames[frame].firstpose;
-	int numposes = paliashdr->frames[frame].numposes;
-
-	if (numposes > 1)
-		posenum += (int)(cl.time / e->lerptime) % numposes;
-
 	if (r_lerpmodels.value && !(e->model->flags & MOD_NOLERP && r_lerpmodels.value != 2))
 	{
-		if (e->lerpflags & LERP_FINISH && numposes == 1)
-			lerpdata->blend = CLAMP (0, (cl.time - e->lerpstart) / (e->lerpfinish - e->lerpstart), 1);
-		else
-			lerpdata->blend = CLAMP (0, (cl.time - e->lerpstart) / e->lerptime, 1);
+		int	   numposes = paliashdr->frames[frame].numposes;
+		double change_time = e->lerp.frame_change_time;
 
-		lerpdata->pose1 = e->previouspose;
-		lerpdata->pose2 = e->currentpose;
+		if (numposes > 1)
+		{
+			// framegroup: poses advance with cl.time; lerp from the previous
+			// group pose unless the entity entered this frame more recently
+			double interval = paliashdr->frames[frame].interval;
+			int	   idx = (int)(cl.time / interval);
+			double boundary = idx * interval;
+
+			lerpdata->pose2 = paliashdr->frames[frame].firstpose + idx % numposes;
+			if (change_time > boundary)
+			{
+				lerpdata->pose1 = R_EntityPoseAt (paliashdr, e->lerp.prev_frame, change_time);
+				lerpdata->blend = CLAMP (0, (cl.time - change_time) / interval, 1);
+			}
+			else
+			{
+				lerpdata->pose1 = paliashdr->frames[frame].firstpose + (idx + numposes - 1) % numposes;
+				lerpdata->blend = CLAMP (0, (cl.time - boundary) / interval, 1);
+			}
+		}
+		else if (change_time > 0)
+		{
+			double duration = (e->lerp.frame_duration > 0) ? e->lerp.frame_duration : 0.1;
+			lerpdata->pose2 = paliashdr->frames[frame].firstpose;
+			lerpdata->pose1 = R_EntityPoseAt (paliashdr, e->lerp.prev_frame, change_time);
+			lerpdata->blend = CLAMP (0, (cl.time - change_time) / duration, 1);
+		}
+		else
+		{
+			lerpdata->pose2 = paliashdr->frames[frame].firstpose;
+			lerpdata->pose1 = lerpdata->pose2;
+			lerpdata->blend = 1;
+		}
 
 		// Clamp poses (safety check for Quake1 models)
 		if (paliashdr->poseverttype == PV_QUAKE1)
@@ -321,39 +302,8 @@ void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, int frame, lerpdata_
 	else
 	{
 		lerpdata->blend = 1;
-		lerpdata->pose1 = posenum;
-		lerpdata->pose2 = posenum;
-	}
-}
-
-/*
-=================
-R_UpdateEntityMoveState
-
-Updates entity movement state (previousorigin, currentorigin, etc.).
-Call once per frame when entity becomes visible, before R_GetEntityLerpedTransform.
-=================
-*/
-void R_UpdateEntityMoveState (entity_t *e)
-{
-	// if LERP_RESETMOVE, kill any lerps in progress
-	if (e->lerpflags & LERP_RESETMOVE)
-	{
-		e->movelerpstart = 0;
-		VectorCopy (e->origin, e->previousorigin);
-		VectorCopy (e->origin, e->currentorigin);
-		VectorCopy (e->angles, e->previousangles);
-		VectorCopy (e->angles, e->currentangles);
-		e->lerpflags -= LERP_RESETMOVE;
-	}
-	else if (!VectorCompare (e->origin, e->currentorigin) || (r_lerpturn.value && !VectorCompare (e->angles, e->currentangles)))
-	{
-		// origin/angles changed, start new lerp
-		e->movelerpstart = cl.time;
-		VectorCopy (e->currentorigin, e->previousorigin);
-		VectorCopy (e->origin, e->currentorigin);
-		VectorCopy (e->currentangles, e->previousangles);
-		VectorCopy (e->angles, e->currentangles);
+		lerpdata->pose1 = R_EntityPoseAt (paliashdr, frame, cl.time);
+		lerpdata->pose2 = lerpdata->pose1;
 	}
 }
 
@@ -361,31 +311,32 @@ void R_UpdateEntityMoveState (entity_t *e)
 =================
 R_GetEntityLerpedTransform
 
-Computes lerped origin/angles from stable entity state.
-Call R_UpdateEntityMoveState first to update entity state.
+Computes lerped origin/angles from the parse-side interpolation state and
+cl.time. Does not modify the entity.
+
+Attached entities (tagentity) use their post-attachment origin/angles, which
+only exist on the entity itself.
 =================
 */
-void R_GetEntityLerpedTransform (entity_t *e, vec3_t out_origin, vec3_t out_angles)
+void R_GetEntityLerpedTransform (const entity_t *e, vec3_t out_origin, vec3_t out_angles)
 {
-	if (r_lerpmove.value && e != &cl.viewent && e->lerpflags & LERP_MOVESTEP)
+	if (r_lerpmove.value && e != &cl.viewent && e->lerp.movestep && !e->netstate.tagentity && e->lerp.move_change_time > 0)
 	{
-		float blend;
-		if (e->lerpflags & LERP_FINISH)
-			blend = CLAMP (0, (cl.time - e->movelerpstart) / (e->lerpfinish - e->movelerpstart), 1);
-		else
-			blend = CLAMP (0, (cl.time - e->movelerpstart) / 0.1, 1);
+		double change_time = e->lerp.move_change_time;
+		double duration = (e->lerp.move_duration > 0) ? e->lerp.move_duration : 0.1;
+		float  blend = CLAMP (0, (cl.time - change_time) / duration, 1);
 
 		// translation
 		vec3_t d;
-		VectorSubtract (e->currentorigin, e->previousorigin, d);
-		out_origin[0] = e->previousorigin[0] + d[0] * blend;
-		out_origin[1] = e->previousorigin[1] + d[1] * blend;
-		out_origin[2] = e->previousorigin[2] + d[2] * blend;
+		VectorSubtract (e->msg_origins[0], e->lerp.prev_origin, d);
+		out_origin[0] = e->lerp.prev_origin[0] + d[0] * blend;
+		out_origin[1] = e->lerp.prev_origin[1] + d[1] * blend;
+		out_origin[2] = e->lerp.prev_origin[2] + d[2] * blend;
 
-		// rotation (if enabled)
-		if (r_lerpturn.value)
+		// rotation (if enabled); EF_ROTATE angles are client-side and only exist on the entity
+		if (r_lerpturn.value && !(e->model->flags & EF_ROTATE))
 		{
-			VectorSubtract (e->currentangles, e->previousangles, d);
+			VectorSubtract (e->msg_angles[0], e->lerp.prev_angles, d);
 			for (int i = 0; i < 3; i++)
 			{
 				if (d[i] > 180)
@@ -393,9 +344,9 @@ void R_GetEntityLerpedTransform (entity_t *e, vec3_t out_origin, vec3_t out_angl
 				if (d[i] < -180)
 					d[i] += 360;
 			}
-			out_angles[0] = e->previousangles[0] + d[0] * blend;
-			out_angles[1] = e->previousangles[1] + d[1] * blend;
-			out_angles[2] = e->previousangles[2] + d[2] * blend;
+			out_angles[0] = e->lerp.prev_angles[0] + d[0] * blend;
+			out_angles[1] = e->lerp.prev_angles[1] + d[1] * blend;
+			out_angles[2] = e->lerp.prev_angles[2] + d[2] * blend;
 		}
 		else
 		{
@@ -535,7 +486,7 @@ void R_DrawAliasModel (cb_context_t *cbx, entity_t *e, int *aliaspolys)
 
 	qboolean alphatest = !!(e->model->flags & MF_HOLEY);
 
-	R_SetupAliasFrame (e, paliashdr, e->frame, &lerpdata);
+	R_SetupAliasFrame (e, paliashdr, &lerpdata);
 	R_GetEntityLerpedTransform (e, lerpdata.origin, lerpdata.angles);
 
 	//
@@ -663,7 +614,7 @@ void R_DrawAliasModel_ShowTris (cb_context_t *cbx, entity_t *e)
 	//
 	paliashdr = (aliashdr_t *)Mod_Extradata_CheckSkin (e->model, e->skinnum);
 
-	R_SetupAliasFrame (e, paliashdr, e->frame, &lerpdata);
+	R_SetupAliasFrame (e, paliashdr, &lerpdata);
 	R_GetEntityLerpedTransform (e, lerpdata.origin, lerpdata.angles);
 
 	//

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -48,14 +48,6 @@ typedef struct lightcache_s
 	short  dt;
 } lightcache_t;
 
-// johnfitz -- for lerping
-#define LERP_MOVESTEP	(1 << 0) // this is a MOVETYPE_STEP entity, enable movement lerp
-#define LERP_RESETANIM	(1 << 1) // disable anim lerping until next anim frame
-#define LERP_RESETANIM2 (1 << 2) // set this and previous flag to disable anim lerping for two anim frames
-#define LERP_RESETMOVE	(1 << 3) // disable movement lerping until next origin/angles change
-#define LERP_FINISH		(1 << 4) // use lerpfinish time from server update instead of assuming interval of 0.1
-// johnfitz
-
 // Separate allocation for RT BLAS state (hot/cold split for cache efficiency)
 typedef struct entity_blas_s
 {
@@ -69,9 +61,26 @@ typedef struct entity_blas_s
 	qboolean				   needs_initial_build;
 } entity_blas_t;
 
+// Entity interpolation state. Written only by the parse layer (view.c for the
+// view weapon), read by the renderer. Change times are server (message) times.
+typedef struct entlerp_s
+{
+	qboolean movestep;			// this is a MOVETYPE_STEP entity, enable movement lerp
+	int		 prev_frame;		// frame before the current e->frame; equal to e->frame when the transition must not be lerped
+	double	 frame_change_time; // server time the current frame took effect; 0 = show current frame without lerping
+	double	 frame_duration;	// duration of the current frame transition, frozen when the change was recorded
+	double	 frame_finish_time; // latest server hint (U_LERPFINISH) for the next frame change; becomes the duration of the next transition
+	int		 snap_frames;		// pending frame changes to show without lerping (muzzleflash)
+	double	 snap_msgtime;		// server time of the update that armed snap_frames, to arm once per update
+	vec3_t	 prev_origin;		// origin/angles before msg_origins[0]/msg_angles[0]; shifted only when they change
+	vec3_t	 prev_angles;
+	double	 move_change_time; // server time msg_origins[0]/msg_angles[0] took effect; 0 = don't lerp movement
+	double	 move_duration;	   // duration of the current movement transition, frozen when the change was recorded
+} entlerp_t;
+
 typedef struct entity_s
 {
-	qboolean forcelink; // model changed
+	qboolean forcelink; // no previous update to lerp from, snap to the new state
 
 	int update_type;
 
@@ -101,20 +110,9 @@ typedef struct entity_s
 							 //  that splits bmodel, or NULL if
 							 //  not split
 
-	byte   eflags;		 // spike -- mostly a mirror of netstate, but handles tag inheritance (eww!)
-	byte   alpha;		 // johnfitz -- alpha
-	byte   lerpflags;	 // johnfitz -- lerping
-	float  lerpstart;	 // johnfitz -- animation lerping
-	float  lerptime;	 // johnfitz -- animation lerping
-	float  lerpfinish;	 // johnfitz -- lerping -- server sent us a more accurate interval, use it instead of 0.1
-	short  previouspose; // johnfitz -- animation lerping
-	short  currentpose;	 // johnfitz -- animation lerping
-	//	short					futurepose;		//johnfitz -- animation lerping
-	float  movelerpstart;  // johnfitz -- transform lerping
-	vec3_t previousorigin; // johnfitz -- transform lerping
-	vec3_t currentorigin;  // johnfitz -- transform lerping
-	vec3_t previousangles; // johnfitz -- transform lerping
-	vec3_t currentangles;  // johnfitz -- transform lerping
+	byte	  eflags; // spike -- mostly a mirror of netstate, but handles tag inheritance (eww!)
+	byte	  alpha;  // johnfitz -- alpha
+	entlerp_t lerp;
 
 #ifdef PSET_SCRIPT
 	struct trailstate_s *trailstate; // spike -- managed by the particle system, so we don't loose our position and spawn the wrong number of particles, and we

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -869,7 +869,7 @@ void SV_BuildEntityState (edict_t *ent, entity_state_t *state)
 	state->velocity[0] = state->velocity[1] = state->velocity[2] = 0;
 
 #ifdef LERP_BANDAID
-	state->lerp = ent->sendinterval ? Q_rint ((ent->v.nextthink - qcvm->time) * 1000) + 1 : 0;
+	state->lerp = (ent->sendinterval || ent->sendinterval_default) ? Q_rint ((ent->v.nextthink - qcvm->time) * 1000) + 1 : 0;
 #endif
 }
 
@@ -2145,7 +2145,9 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, size_t overflow
 				bits |= U_FRAME2;
 			if (bits & U_MODEL && (int)ent->v.modelindex & 0xFF00)
 				bits |= U_MODEL2;
-			if (ent->sendinterval)
+			// nonstandard intervals are always sent; the default 0.1 the client assumes anyway is only worth
+			// the extra bytes on clients that are not constrained by the DATAGRAM_MTU packet budget
+			if (ent->sendinterval || (ent->sendinterval_default && client->limit_unreliable > DATAGRAM_MTU))
 				bits |= U_LERPFINISH;
 			if (bits >= 65536)
 				bits |= U_EXTEND1;
@@ -2213,7 +2215,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, size_t overflow
 		if (bits & U_MODEL2)
 			MSG_WriteByte (msg, (int)ent->v.modelindex >> 8);
 		if (bits & U_LERPFINISH)
-			MSG_WriteByte (msg, (byte)(Q_rint ((ent->v.nextthink - qcvm->time) * 255)));
+			MSG_WriteByte (msg, (byte)CLAMP (0, Q_rint ((ent->v.nextthink - qcvm->time) * 255), 255)); // qcvm->time may have advanced past nextthink
 		// johnfitz
 
 		if ((size_t)msg->cursize > origmaxsize)

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -1392,13 +1392,18 @@ void SV_Physics (void)
 
 		// johnfitz -- PROTOCOL_FITZQUAKE
 		// capture interval to nextthink here and send it to client for better
-		// lerp timing, but only if interval is not 0.1 (which client assumes)
+		// lerp timing; ~0.1 intervals match what the client assumes but thinks
+		// fire quantized to server ticks, so the exact value still improves
+		// lerp timing where the extra bytes are affordable
 		ent->sendinterval = false;
+		ent->sendinterval_default = false;
 		if (!ent->free && ent->v.nextthink > qcvm->time &&
 			(ent->v.movetype == MOVETYPE_STEP || ent->v.movetype == MOVETYPE_WALK || ent->v.frame != ent->oldframe))
 		{
 			int j = Q_rint ((ent->v.nextthink - ent->oldthinktime) * 255);
-			if (j >= 0 && j < 256 && j != 25 && j != 26) // 25 and 26 are close enough to 0.1 to not send
+			if (j == 25 || j == 26)
+				ent->sendinterval_default = true;
+			else if (j >= 0 && j < 256)
 				ent->sendinterval = true;
 		}
 		// johnfitz

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -786,16 +786,33 @@ void V_CalcRefdef (void)
 			view->origin[2] += 0.5;
 	}
 
-	if (ent->lerpflags & LERP_FINISH)
+	view->lerp.frame_finish_time = ent->lerp.frame_finish_time;
+
+	// the weapon's frames come from stats, so its change detection lives here
+	// ericw -- model check is done after the upper 8 bits of cl.stats[STAT_WEAPON] are filled in (broke on large maps like zendar.bsp)
+	if (view->model != cl.model_precache[cl.stats[STAT_WEAPON]])
 	{
-		view->lerpflags |= LERP_FINISH;
-		view->lerpfinish = ent->lerpfinish;
+		// don't lerp animation across model changes
+		view->frame = cl.stats[STAT_WEAPONFRAME];
+		view->lerp.prev_frame = view->frame;
+		view->lerp.frame_change_time = 0;
+		view->lerp.snap_frames = 0;
 	}
-	else
-		view->lerpflags &= ~LERP_FINISH;
+	else if (view->frame != cl.stats[STAT_WEAPONFRAME])
+	{
+		if (view->lerp.snap_frames > 0)
+		{
+			view->lerp.snap_frames--;
+			view->lerp.prev_frame = cl.stats[STAT_WEAPONFRAME];
+		}
+		else
+			view->lerp.prev_frame = view->frame;
+		view->frame = cl.stats[STAT_WEAPONFRAME];
+		view->lerp.frame_change_time = cl.mtime[0];
+		view->lerp.frame_duration = (view->lerp.frame_finish_time > cl.mtime[0]) ? view->lerp.frame_finish_time - cl.mtime[0] : 0.1;
+	}
 
 	view->model = cl.model_precache[cl.stats[STAT_WEAPON]];
-	view->frame = cl.stats[STAT_WEAPONFRAME];
 	view->netstate.colormap = 0;
 
 	// johnfitz -- v_gunkick

--- a/format.sh
+++ b/format.sh
@@ -1,2 +1,2 @@
 #/bin/sh
-docker run --user $(id -u):$(id -g) -v `pwd`:`pwd` -w `pwd` -i --rm ghcr.io/jidicula/clang-format:17 -i Quake/*.c Quake/*.h Shaders/*.frag Shaders/*.vert Shaders/*.comp Shaders/*.inc Shaders/*.c Shaders/*.h
+docker run --user $(id -u):$(id -g) -v `pwd`:`pwd` -w `pwd` -i --rm ghcr.io/jidicula/clang-format:18 -i Quake/*.c Quake/*.h Shaders/*.frag Shaders/*.vert Shaders/*.comp Shaders/*.inc Shaders/*.c Shaders/*.h


### PR DESCRIPTION
I did some serious code archeology for this. The code has become an absolute mess and it's because of multiple cooks patching around this for years.

Original Quake had one clock and everything was fine. Positions were interpolated between the last two timestamped server messages, models just snapped to 10Hz.

Then FitzQuake 0.85 added model interpolation and protocol 666 in the same release. Instead of deriving animation timing from the protocol like id did for positions, the renderer guesses based on a heuristic: it diffs cached poses to detect frame changes during drawing, stamps the lerp with the time the renderer noticed, and assumes every frame lasts 0.1s. There is a protocol field for the real timing (U_LERPFINISH) but it's deliberately not sent for 0.1 intervals. All of this was correct as long as there was one clock, because then "noticed" and "happened" are the same time.

Then we took the QSS renderer/server decoupling in 2019 and nobody re-checked the FitzQuake assumptions.

Fix this properly like id did for positions: the parser owns interpolation state and timestamps changes when they arrive. The renderer is a pure function of entity state and cl.time. Then there by design can never be any frame rate dependence or races.

I checked the fiend animation at `host_maxfps 73` and it looks smooth.