### PR TITLE
AppImage: enable pipewire audio driver in SDL3

### DIFF
--- a/Packaging/AppImage/docker/Dockerfile
+++ b/Packaging/AppImage/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
 	libopenal-dev \
 	libpango1.0-dev \
 	libpulse-dev \
+	libpipewire-0.3-dev \
 	libsdl2-dev \
 	libsndio-dev \
 	libudev-dev \


### PR DESCRIPTION
Pipewire is now the dominant audio system on all major Linux distributions. Therefore, enable the Pipewire audio driver  in the SDL3 library  included in  the Linux AppImage.