### PR TITLE
Fix #684 : image is pixelated with HighDPI screens on MacOs/Wayland (SDL3 only)

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -524,6 +524,10 @@ static qboolean VID_SetMode (int width, int height, float refreshrate, qboolean 
 	{
 		flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_VULKAN;
 
+#ifdef USE_SDL3
+		flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
+#endif
+
 		if (vid_borderless.value)
 			flags |= SDL_WINDOW_BORDERLESS;
 		else if (!fullscreen)


### PR DESCRIPTION
The fix is only when using SDL3, SDL2 do not support the required machinery.

Kindly tested by @Perlence in #684, works for him.

The flag is ignored on Windows 10/11 and only applicable for MacOS and supposedly Wayland. 