### PR TITLE
Draw pics caching rework

### DIFF
--- a/Quake/draw.h
+++ b/Quake/draw.h
@@ -30,6 +30,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern qpic_t *draw_disc; // also used on sbar
 
+// clang-format off
+typedef enum
+{
+	PICFLAG_AUTO         = 0,		    // value used when no flags known
+	PICFLAG_WAD          = (1u << 0),   // name matches that of a wad lump
+	PICFLAG_WRAP         = (1u << 2),   // make sure npot stuff doesn't break wrapping.
+	PICFLAG_MIPMAP       = (1u << 3),   // disable use of scrap...
+	PICFLAG_NOLOAD       = (1u << 31)   // To request the cached status only (internal use only, cannot be marshalled from a QuakeC float anyway)
+} picflags_t;
+// clang-format on
+
 // Use float coords and sizes in Draw_XXX to allow sub-pixel precision
 void	Draw_Init (void);
 void	Draw_Character (cb_context_t *cbx, float x, float y, int num);
@@ -42,10 +53,11 @@ void	Draw_Fill (cb_context_t *cbx, float x, float y, float w, float h, int c, fl
 void	Draw_FadeScreen (cb_context_t *cbx);
 void	Draw_String (cb_context_t *cbx, float x, float y, const char *str);
 void	Draw_String_3D (cb_context_t *cbx, vec3_t coords, float size, const char *str);
-qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags);
+qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags, int picflags);
 qpic_t *Draw_PicFromWad (const char *name);
 qpic_t *Draw_CachePic (const char *path);
-qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags);
+qpic_t *Draw_GetCachedPic (const char *path);
+qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags, int picflags);
 void	Draw_NewGame (void);
 
 void GL_Viewport (cb_context_t *cbx, float x, float y, float width, float height, float min_depth, float max_depth);

--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -87,16 +87,20 @@ typedef struct
 
 typedef struct cachepic_s
 {
-	char   name[MAX_QPATH];
-	qpic_t pic;
-	byte   padding[32]; // for appended glpic
+	// dynamically-allocated chained cachepic_t
+	struct cachepic_s *next;
+	char			   name[MAX_QPATH];
+	qpic_t			   pic;
+	int				   picflags;
+	byte			   padding[32]; // for appended glpic
 } cachepic_t;
 
-// TODO : vso : should be dynamically allocated instead ?
-// On the other hand it takes so little memory that we can push MAX_CACHED_PICS very very high and never touch it again.
-#define MAX_CACHED_PICS 8192 // vso : from Spike = 512 - increased to avoid csqc issues.
-static cachepic_t menu_cachepics[MAX_CACHED_PICS];
-static int		  menu_numcachepics;
+// draw_qcvm_mutex also protects q_cachepics  / scrap updates
+extern SDL_Mutex *draw_qcvm_mutex;
+
+static cachepic_t *q_cachepics = NULL;
+// Fast lookup pic name => cachepic_t* from q_cachepics.
+hash_map_t		  *q_cachepics_map = NULL;
 
 //  scrap allocation
 //  Allocate all the little status bar obejcts into a single texture
@@ -118,7 +122,7 @@ Scrap_AllocBlock
 returns an index into scrap_texnums[] and the position inside it
 ================
 */
-int Scrap_AllocBlock (int w, int h, int *x, int *y)
+static int Scrap_AllocBlock (int w, int h, int *x, int *y)
 {
 	int i, j;
 	int best, best2;
@@ -164,7 +168,7 @@ int Scrap_AllocBlock (int w, int h, int *x, int *y)
 Scrap_Upload -- johnfitz -- now uses TexMgr
 ================
 */
-void Scrap_Upload (void)
+static void Scrap_Upload (void)
 {
 	char name[8];
 	int	 i;
@@ -185,25 +189,24 @@ void Scrap_Upload (void)
 Draw_PicFromWad
 ================
 */
-qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags)
+qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags, int picflags)
 {
 	int			 i;
-	cachepic_t	*pic;
 	qpic_t		*p;
+	cachepic_t	*pic;
 	glpic_t		 gl;
 	src_offset_t offset; // johnfitz
 	lumpinfo_t	*info;
 
-	// Spike -- added cachepic stuff here, to avoid glitches if the function is called multiple times with the same image.
-	for (pic = menu_cachepics, i = 0; i < menu_numcachepics; pic++, i++)
-	{
-		if (!strncmp (name, pic->name, countof (pic->name)))
-			return &pic->pic;
-	}
-	if (menu_numcachepics == MAX_CACHED_PICS)
-		Sys_Error ("menu_numcachepics == MAX_CACHED_PICS");
+	// Fast lookup:
+	p = Draw_GetCachedPic (name);
 
+	if (p)
+		return p;
+
+	// not cached, searched for it:
 	p = (qpic_t *)W_GetLumpName (name, &info);
+
 	if (!p)
 	{
 		Con_Warning ("W_GetLumpName: %s not found\n", name);
@@ -266,17 +269,44 @@ qpic_t *Draw_PicFromWad2 (const char *name, unsigned int texflags)
 		gl.th = 1;
 	}
 
-	menu_numcachepics++;
+	// Create a new pic:
+	pic = Mem_Alloc (sizeof (*pic));
+	pic->picflags = picflags;
+
 	q_strlcpy (pic->name, name, countof (pic->name));
 	pic->pic = *p;
+
 	memcpy ((void *)&(pic->pic.data), &gl, sizeof (glpic_t));
+
+	// Add to cache:
+	if (!q_cachepics)
+	{
+		q_cachepics = pic;
+	}
+	else
+	{
+		cachepic_t *current_pic = q_cachepics;
+		cachepic_t *previous_pic = q_cachepics;
+
+		while (current_pic)
+		{
+			previous_pic = current_pic;
+			current_pic = current_pic->next;
+		}
+
+		previous_pic->next = pic;
+	}
+
+	// we must downgrade pic->name as a pointer because the hashmap expects a key 8 bytes long (const char*)
+	const char *pic_name_as_pointer = &pic->name[0];
+	HashMap_Insert (q_cachepics_map, &pic_name_as_pointer, &pic);
 
 	return &pic->pic;
 }
 
 qpic_t *Draw_PicFromWad (const char *name)
 {
-	return Draw_PicFromWad2 (name, TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP);
+	return Draw_PicFromWad2 (name, TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP, PICFLAG_AUTO);
 }
 #if 0 // vso - unused 
 static qpic_t *Draw_GetCachedPic (const char *path)
@@ -294,22 +324,39 @@ static qpic_t *Draw_GetCachedPic (const char *path)
 #endif
 /*
 ================
+Draw_GetCachedPic : get a pic from cache if already present, or return NULL if not.
+================
+*/
+qpic_t *Draw_GetCachedPic (const char *path)
+{
+	// Fast lookup:
+	cachepic_t **pic_ptr = HashMap_Lookup (cachepic_t *, q_cachepics_map, &path);
+
+	// found
+	if (pic_ptr)
+	{
+		return &((*pic_ptr)->pic);
+	}
+
+	return NULL;
+}
+
+/*
+================
 Draw_CachePic
 ================
 */
-qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
+qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags, int picflags)
 {
+	qpic_t	   *p;
 	cachepic_t *pic;
-	int			i;
 	glpic_t		gl;
 
-	for (pic = menu_cachepics, i = 0; i < menu_numcachepics; pic++, i++)
-	{
-		if (!strncmp (path, pic->name, countof (pic->name)))
-			return &pic->pic;
-	}
-	if (menu_numcachepics == MAX_CACHED_PICS)
-		Sys_Error ("menu_numcachepics == MAX_CACHED_PICS");
+	// Fast lookup:
+	p = Draw_GetCachedPic (path);
+
+	if (p)
+		return p;
 
 	//
 	// load the pic from disk
@@ -327,9 +374,14 @@ qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
 	pic_data = Image_LoadImage (npath, (int *)&pic_width, (int *)&pic_height, &pic_fmt, 0);
 
 	if (!pic_data)
+	{
 		return NULL;
+	}
 
-	menu_numcachepics++;
+	// Create a new pic:
+	pic = Mem_Alloc (sizeof (*pic));
+	pic->picflags = picflags;
+
 	q_strlcpy (pic->name, path, countof (pic->name));
 
 	pic->pic.width = pic_width;
@@ -347,6 +399,28 @@ qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
 
 	memcpy ((void *)&(pic->pic.data), &gl, sizeof (glpic_t));
 
+	// Add to cache:
+	if (!q_cachepics)
+	{
+		q_cachepics = pic;
+	}
+	else
+	{
+		cachepic_t *current_pic = q_cachepics;
+		cachepic_t *previous_pic = q_cachepics;
+
+		while (current_pic)
+		{
+			previous_pic = current_pic;
+			current_pic = current_pic->next;
+		}
+
+		previous_pic->next = pic;
+	}
+	// we must downgrade pic->name as a pointer because the hashmap expects a key 8 bytes long (const char*)
+	const char *pic_name_as_pointer = &pic->name[0];
+	HashMap_Insert (q_cachepics_map, &pic_name_as_pointer, &pic);
+
 	Mem_Free (pic_data);
 
 	return &pic->pic;
@@ -354,7 +428,7 @@ qpic_t *Draw_TryCachePic (const char *path, unsigned int texflags)
 
 qpic_t *Draw_CachePic (const char *path)
 {
-	qpic_t *pic = Draw_TryCachePic (path, TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP);
+	qpic_t *pic = Draw_TryCachePic (path, TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP, PICFLAG_AUTO);
 	if (!pic)
 		Sys_Error ("Draw_CachePic: failed to load %s", path);
 	return pic;
@@ -421,8 +495,7 @@ Draw_NewGame -- johnfitz
 */
 void Draw_NewGame (void)
 {
-	cachepic_t *pic;
-	int			i;
+	SDL_LockMutex (draw_qcvm_mutex);
 
 	// empty scrap and reallocate gltextures
 	memset (scrap_allocated, 0, sizeof (scrap_allocated));
@@ -430,17 +503,27 @@ void Draw_NewGame (void)
 
 	Scrap_Upload (); // creates 2 empty gltextures
 
-	// empty lmp cache
-	for (pic = menu_cachepics, i = 0; i < menu_numcachepics; pic++, i++)
-		pic->name[0] = 0;
-	menu_numcachepics = 0;
+	// empty pic cache :
+	cachepic_t *cached_pic = q_cachepics;
+	cachepic_t *next_cached_pic;
+
+	while (cached_pic)
+	{
+		next_cached_pic = cached_pic->next;
+		Mem_Free (cached_pic);
+		cached_pic = next_cached_pic;
+	}
+	q_cachepics = NULL;
+
+	HashMap_Clear (q_cachepics_map);
 
 	// reload wad pics
 	W_LoadWadFile (); // johnfitz -- filename is now hard-coded for honesty
 	Draw_LoadPics ();
 	SCR_LoadPics ();
 	Sbar_LoadPics ();
-	PR_ReloadPics (false);
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 
 /*
@@ -450,6 +533,8 @@ Draw_Init -- johnfitz -- rewritten
 */
 void Draw_Init (void)
 {
+	q_cachepics_map = HashMap_Create (const char *, cachepic_t *, &HashStr, &HashStrCmp);
+
 	Cvar_RegisterVariable (&scr_conalpha);
 
 	// clear scrap and allocate gltextures

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -93,6 +93,8 @@ static SDL_Mutex *uniform_allocate_mutex;
 static SDL_Mutex *storage_allocate_mutex;
 static SDL_Mutex *garbage_mutex;
 
+extern SDL_Mutex *draw_qcvm_mutex;
+
 qboolean R_UseAlphaSort (void)
 {
 	return r_alphasort.value && !R_UseOIT ();
@@ -263,8 +265,6 @@ static void R_ShowbboxesFilter_Completion_f (const char *partial)
 	if (!sv.active)
 		return;
 
-	extern SDL_Mutex *draw_qcvm_mutex;
-
 	SDL_LockMutex (draw_qcvm_mutex);
 	PR_SwitchQCVM (&sv.qcvm);
 
@@ -289,9 +289,8 @@ R_ShowbboxesFilterClear_f
 */
 static void R_ShowbboxesFilterClear_f (void)
 {
-	extern char		 *r_showbboxes_filter_strings;
-	extern qboolean	  r_showbboxes_filter_byindex;
-	extern SDL_Mutex *draw_qcvm_mutex;
+	extern char	   *r_showbboxes_filter_strings;
+	extern qboolean r_showbboxes_filter_byindex;
 
 	SDL_LockMutex (draw_qcvm_mutex);
 

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1134,13 +1134,11 @@ static void SCR_DrawGUI (void *unused)
 	SCR_TileClear (cbx);
 
 	const qboolean cscqhud = (scr_style.value < 1.0f) && cl.qcvm.extfuncs.CSQC_DrawHud;
-	qboolean	   use_mutex = r_showbboxes.value && cscqhud;
-
-	if (use_mutex)
-		SDL_LockMutex (draw_qcvm_mutex);
 
 	if (cscqhud && setjmp (screen_error))
 		PR_ClearProgs (&cl.qcvm);
+
+	SDL_LockMutex (draw_qcvm_mutex);
 
 	if (scr_drawdialog) // new game confirm
 	{
@@ -1181,9 +1179,7 @@ static void SCR_DrawGUI (void *unused)
 		M_Draw (cbx);
 	}
 
-	if (use_mutex)
-		SDL_UnlockMutex (draw_qcvm_mutex);
-
+	SDL_UnlockMutex (draw_qcvm_mutex);
 	R_EndDebugUtilsLabel (cbx);
 }
 

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -278,7 +278,7 @@ M_DrawPic
 */
 void M_DrawPic (cb_context_t *cbx, int x, int y, qpic_t *pic)
 {
-	Draw_Pic (cbx, x, y, pic, 1.0f, false); // johnfitz -- simplified becuase centering is handled elsewhere
+	Draw_Pic (cbx, x, y, pic, 1.0f, false); // johnfitz -- simplified because centering is handled elsewhere
 }
 
 /*
@@ -632,7 +632,7 @@ static qpic_t *Get_Menu2 ()
 {
 	qboolean base_game = COM_GetGameNames (false)[0] == 0;
 	// Check if user has actually installed vkquake.pak, otherwise fall back to old menu
-	return (base_game && registered.value) ? Draw_TryCachePic ("gfx/mainmenu2.lmp", TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP) : NULL;
+	return (base_game && registered.value) ? Draw_TryCachePic ("gfx/mainmenu2.lmp", TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP, PICFLAG_AUTO) : NULL;
 }
 
 void M_Main_Draw (cb_context_t *cbx)

--- a/Quake/pr_ext.c
+++ b/Quake/pr_ext.c
@@ -53,6 +53,9 @@ static int pr_ext_warned_particleeffectnum;						  // so these only spam once pe
 
 extern qpic_t *pic_nul;
 
+// draw_qcvm_mutex also protects q_cachepics  / scrap updates
+extern SDL_Mutex *draw_qcvm_mutex;
+
 static void *PR_FindExtGlobal (int type, const char *name);
 void		 SV_CheckVelocity (edict_t *ent);
 
@@ -4733,45 +4736,18 @@ static void PF_cl_getstat_string (void)
 	}
 }
 
-static struct
-{
-	char		 name[MAX_QPATH];
-	unsigned int flags;
-	qpic_t		*pic;
-}			 *qcpics;
-static size_t numqcpics;
-static size_t maxqcpics;
-
-void PR_ReloadPics (qboolean purge)
-{
-	numqcpics = 0;
-
-	Mem_Free (qcpics);
-	qcpics = NULL;
-	maxqcpics = 0;
-}
-
-#define PICFLAG_AUTO   0		 // value used when no flags known
-#define PICFLAG_WAD	   (1u << 0) // name matches that of a wad lump
-#define PICFLAG_WRAP   (1u << 2) // make sure npot stuff doesn't break wrapping.
-#define PICFLAG_MIPMAP (1u << 3) // disable use of scrap...
-#define PICFLAG_BLOCK  (1u << 9) // wait until the texture is fully loaded.
-#define PICFLAG_NOLOAD (1u << 31)
-
-static qpic_t *DrawQC_CachePic (const char *picname, unsigned int flags)
+static qpic_t *DrawQC_CachePic (const char *picname, int picflags)
 {
 	if (strlen (picname) >= MAX_QPATH)
 		return NULL; // too long. get lost.
 
-	// okay, so this is silly. we've ended up with 3 different cache levels. qcpics, pics, and images.
-	size_t		 i;
-	unsigned int texflags;
+	unsigned int texflags = TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP;
 
 	// cleanup picname of all its leading slashes or backslashes
 	// because sometimes the input is silly.
-	char tmp_qpic_name[countof (qcpics[i].name)] = {0};
+	char tmp_qpic_name[MAX_QPATH] = {0};
 
-	q_strlcpy (tmp_qpic_name, picname, countof (qcpics[i].name));
+	q_strlcpy (tmp_qpic_name, picname, MAX_QPATH);
 
 	char *clean_picname = &tmp_qpic_name[0];
 
@@ -4779,53 +4755,35 @@ static qpic_t *DrawQC_CachePic (const char *picname, unsigned int flags)
 	while (*clean_picname == '/' || *clean_picname == '\\')
 		clean_picname++;
 
-	for (i = 0; i < numqcpics; i++)
-	{
-		// binary search? something more sane?
-		if (!strcmp (clean_picname, qcpics[i].name))
-		{
-			if (qcpics[i].pic)
-				return qcpics[i].pic;
-		}
-	}
+	// Fast lookup:
+	qpic_t *p = Draw_GetCachedPic (clean_picname);
 
-	if (flags & PICFLAG_NOLOAD)
-		return NULL; // its a query, not actually needed.
+	if (p)
+		return p;
 
-	if (i + 1 > maxqcpics)
-	{
-		maxqcpics = i + 32;
-		qcpics = Mem_Realloc (qcpics, maxqcpics * sizeof (*qcpics));
-	}
+	if (picflags & PICFLAG_NOLOAD)
+		return NULL; // only query the cached status.
 
-	strcpy (qcpics[i].name, clean_picname);
-
-	qcpics[i].flags = flags;
-	qcpics[i].pic = NULL;
-
-	texflags = TEXPREF_ALPHA | TEXPREF_PAD | TEXPREF_NOPICMIP;
-	if (flags & PICFLAG_WRAP)
+	// load a new pic:
+	if (picflags & PICFLAG_WRAP)
 		texflags &= ~TEXPREF_PAD; // don't allow padding if its going to need to wrap (even if we don't enable clamp-to-edge normally). I just hope we have
 								  // npot support.
-	if (flags & PICFLAG_MIPMAP)
+	if (picflags & PICFLAG_MIPMAP)
 		texflags |= TEXPREF_MIPMAP;
 
 	// try to load it from a wad if applicable.
 	// the extra gfx/ crap is because DP insists on it for wad images. and its a nightmare to get things working in all engines if we don't accept that quirk
 	// too.
-	if (flags & PICFLAG_WAD)
-		qcpics[i].pic = Draw_PicFromWad2 (clean_picname + (strncmp (clean_picname, "gfx/", 4) ? 0 : 4), texflags);
+	if (picflags & PICFLAG_WAD)
+		p = Draw_PicFromWad2 (clean_picname + (strncmp (clean_picname, "gfx/", 4) ? 0 : 4), texflags, picflags);
 	else if (!strncmp (clean_picname, "gfx/", 4) && !strchr (clean_picname + 4, '.'))
-		qcpics[i].pic = Draw_PicFromWad2 (clean_picname + 4, texflags);
+		p = Draw_PicFromWad2 (clean_picname + 4, texflags, picflags);
 
 	// okay, not a wad pic, try and load a png/tga/jpg/pcx/lmp
-	if (!qcpics[i].pic || qcpics[i].pic == pic_nul)
-		qcpics[i].pic = Draw_TryCachePic (clean_picname, texflags);
+	if (!p || p == pic_nul)
+		p = Draw_TryCachePic (clean_picname, texflags, picflags);
 
-	if (i == numqcpics)
-		numqcpics++;
-
-	return qcpics[i].pic;
+	return p;
 }
 extern gltexture_t *char_texture;
 static void			DrawQC_CharacterQuad (cb_context_t *cbx, float x, float y, int num, float w, float h, float *rgb, float alpha)
@@ -5003,25 +4961,35 @@ static void PF_cl_drawresetclip (void)
 
 static void PF_cl_precachepic (void)
 {
-	const char	*name = G_STRING (OFS_PARM0);
-	unsigned int flags = G_FLOAT (OFS_PARM1);
+	const char *name = G_STRING (OFS_PARM0);
+	int			flags = (int)G_FLOAT (OFS_PARM1);
 
 	G_INT (OFS_RETURN) = G_INT (OFS_PARM0); // return input string, for convienience
 
-	if (!DrawQC_CachePic (name, flags) && (flags & PICFLAG_BLOCK))
+	SDL_LockMutex (draw_qcvm_mutex);
+
+	if (!DrawQC_CachePic (name, flags))
+		// failure to load because the pic 'name" was not found.
 		G_INT (OFS_RETURN) = 0; // return input string, for convienience
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 static void PF_cl_iscachedpic (void)
 {
+	SDL_LockMutex (draw_qcvm_mutex);
 	const char *name = G_STRING (OFS_PARM0);
 	if (DrawQC_CachePic (name, PICFLAG_NOLOAD))
 		G_FLOAT (OFS_RETURN) = true;
 	else
 		G_FLOAT (OFS_RETURN) = false;
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 
 static void PF_cl_drawpic (void)
 {
+	SDL_LockMutex (draw_qcvm_mutex);
+
 	float  *pos = G_VECTOR (OFS_PARM0);
 	qpic_t *pic = DrawQC_CachePic (G_STRING (OFS_PARM1), PICFLAG_AUTO);
 	float  *size = G_VECTOR (OFS_PARM2);
@@ -5030,19 +4998,27 @@ static void PF_cl_drawpic (void)
 
 	if (pic)
 		Draw_SubPic (vulkan_globals.secondary_cb_contexts[SCBX_GUI], pos[0], pos[1], size[0], size[1], pic, 0, 0, 1, 1, rgb, alpha);
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 
 static void PF_cl_getimagesize (void)
 {
+	SDL_LockMutex (draw_qcvm_mutex);
+
 	qpic_t *pic = DrawQC_CachePic (G_STRING (OFS_PARM0), PICFLAG_AUTO);
 	if (pic)
 		G_VECTORSET (OFS_RETURN, pic->width, pic->height, 0);
 	else
 		G_VECTORSET (OFS_RETURN, 0, 0, 0);
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 
 static void PF_cl_drawsubpic (void)
 {
+	SDL_LockMutex (draw_qcvm_mutex);
+
 	float  *pos = G_VECTOR (OFS_PARM0);
 	float  *size = G_VECTOR (OFS_PARM1);
 	qpic_t *pic = DrawQC_CachePic (G_STRING (OFS_PARM2), PICFLAG_AUTO);
@@ -5054,6 +5030,8 @@ static void PF_cl_drawsubpic (void)
 	if (pic)
 		Draw_SubPic (
 			vulkan_globals.secondary_cb_contexts[SCBX_GUI], pos[0], pos[1], size[0], size[1], pic, srcpos[0], srcpos[1], srcsize[0], srcsize[1], rgb, alpha);
+
+	SDL_UnlockMutex (draw_qcvm_mutex);
 }
 
 static void PF_cl_drawfill (void)

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -95,7 +95,6 @@ void   PR_InitExtensions (void);
 void   PR_EnableExtensions (ddef_t *pr_globaldefs); // adds in the extra builtins etc
 void   PR_AutoCvarChanged (cvar_t *var);			// updates the autocvar_ globals when their cvar is changed
 void   PR_ShutdownExtensions (void);				// nooooes!
-void   PR_ReloadPics (qboolean purge);				// for gamedir or video changes
 func_t PR_FindExtFunction (const char *entryname);
 void   PR_DumpPlatform_f (void); // console command: writes out a qsextensions.qc file
 // special hacks...

--- a/Quake/sbar.c
+++ b/Quake/sbar.c
@@ -108,13 +108,13 @@ Sbar_DontShowScores
 Tab key up
 ===============
 */
-void Sbar_DontShowScores (void)
+static void Sbar_DontShowScores (void)
 {
 	Sbar_CSQCCommand ();
 	sb_showscores = false;
 }
 
-qpic_t *Sbar_CheckPicFromWad (const char *name)
+static qpic_t *Sbar_CheckPicFromWad (const char *name)
 {
 	extern qpic_t *pic_nul;
 	qpic_t		  *r;


### PR DESCRIPTION
- Unified cache for menu and CSQC pics
- Dynamically allocated entries
- Fast pic name to pic lookup using hash map
- Protect scrap / pic cache update from CSQC with the same mutex as SCR_DrawGUI