### PR TITLE
Update meson.build

### DIFF
--- a/Quake/common.make
+++ b/Quake/common.make
@@ -17,7 +17,7 @@ endif
 
 CHECK_GCC = $(shell if echo | $(CC) $(1) -Werror -S -o /dev/null -xc - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
 
-CFLAGS += -MMD -Wall -Wno-trigraphs -Werror -std=gnu11
+CFLAGS += -MMD -Wall -Wno-trigraphs -Werror -std=gnu11 -fno-common
 ifneq ($(HOST_OS),darwin)
 CFLAGS += -D_FILE_OFFSET_BITS=64
 endif

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,9 @@ cc = meson.get_compiler('c')
 # Always build keeping frame pointers to get better backtraces
 add_project_arguments(cc.get_supported_arguments('-fno-omit-frame-pointer', '/Oy-'), language: 'c')
 
+# Ask linker not to locate uninitialized variables into COMMON (will use .bss then) to avoid macOS link issue
+add_project_arguments('-fno-common', language: 'c')
+
 if host_machine.system() == 'windows'
     foreach native : [true, false]
         add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', '-D_CRT_NONSTDC_NO_DEPRECATE', '-D_WINSOCK_DEPRECATED_NO_WARNINGS', language : 'c', native : native)


### PR DESCRIPTION
An update to clang broke the build in the linker stage for macOS arm64 builds due to usage of the legacy COMMON symbol. This symbol carries restrictions with it (distance of pointer fixups). Avoiding the COMMON placement will fix this. This change is neutral to other targets.

See #985 