### PR TITLE
some cleanup of no longer required gcc diagnostic  and  unnecessary code

### DIFF
--- a/Quake/mem.c
+++ b/Quake/mem.c
@@ -32,12 +32,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #if defined(USE_MI_MALLOC)
 
-#if defined(__GNUC__) && (__GNUC__ >= 12)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow" +
-#pragma message "ignore stringop-overflow warnings for mimalloc v2.14+"
-#endif
-
 #undef snprintf
 #define snprintf q_snprintf
 #undef vsnprintf
@@ -50,10 +44,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 #include "mimalloc/static.c"
-
-#if defined(__GNUC__) && (__GNUC__ >= 12)
-#pragma GCC diagnostic pop // Restore warnings on GCC
-#endif
 
 #elif defined(USE_CRT_MALLOC)
 #include <stdlib.h>

--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -978,6 +978,9 @@ void ED_PrintEdicts (void)
 	int free_edicts_count = 0;
 	int free_list_count = 0;
 
+	Q_UNUSED (free_edicts_count);
+	Q_UNUSED (free_list_count);
+
 	PR_SwitchQCVM (&sv.qcvm);
 
 	ED_CheckFreeList ();
@@ -1012,11 +1015,6 @@ void ED_PrintEdicts (void)
 	assert (free_list_count == free_edicts_count);
 
 	Con_Printf ("Total: %i entities\n", qcvm->num_edicts);
-
-	if (free_list_count != free_edicts_count)
-	{
-		Con_Warning ("free_list_count:%i is not equal to free_edicts_count:%i\n", free_list_count, free_edicts_count);
-	}
 
 	PR_SwitchQCVM (NULL);
 }


### PR DESCRIPTION
- drop  the GCC diagnostic  PRAGMAS (introduced in commit  https://github.com/Novum/vkQuake/commit/64d83d4fa51fd5f5fec8e15751d0d28009d3d6b6), they were  required for building  with earlier versions of mimalloc  
- proper handling of  "[[maybe_unused]]" variables.   how did I miss `Q_UNUSED()`? 