### PR TITLE
Fix window growing on every launch on high pixel density displays

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -296,6 +296,32 @@ static int VID_GetCurrentHeight (void)
 }
 
 /*
+================
+VID_GetCurrentWindowWidth
+
+Window size in points; vid.width / vid.height are in pixels.
+================
+*/
+static int VID_GetCurrentWindowWidth (void)
+{
+	int w = 0, h = 0;
+	SDL_GetWindowSize (draw_context, &w, &h);
+	return w;
+}
+
+/*
+================
+VID_GetCurrentWindowHeight
+================
+*/
+static int VID_GetCurrentWindowHeight (void)
+{
+	int w = 0, h = 0;
+	SDL_GetWindowSize (draw_context, &w, &h);
+	return h;
+}
+
+/*
 ====================
 VID_GetCurrentRefreshRate
 ====================
@@ -691,8 +717,8 @@ static void VID_Test (void)
 	//
 	// now try the switch
 	//
-	old_width = VID_GetCurrentWidth ();
-	old_height = VID_GetCurrentHeight ();
+	old_width = VID_GetCurrentWindowWidth ();
+	old_height = VID_GetCurrentWindowHeight ();
 	old_refreshrate = VID_GetCurrentRefreshRate ();
 	old_fullscreen = VID_GetFullscreen () ? (vulkan_globals.swap_chain_full_screen_exclusive ? 2 : 1) : 0;
 	VID_Restart (true);
@@ -4907,8 +4933,8 @@ void VID_SyncCvars (void)
 	{
 		if (!VID_GetDesktopFullscreen ())
 		{
-			Cvar_SetValueQuick (&vid_width, VID_GetCurrentWidth ());
-			Cvar_SetValueQuick (&vid_height, VID_GetCurrentHeight ());
+			Cvar_SetValueQuick (&vid_width, VID_GetCurrentWindowWidth ());
+			Cvar_SetValueQuick (&vid_height, VID_GetCurrentWindowHeight ());
 		}
 		Cvar_SetValueQuick (&vid_refreshrate, VID_GetCurrentRefreshRate ());
 		Cvar_SetQuick (&vid_fullscreen, VID_GetFullscreen () ? (vulkan_globals.want_full_screen_exclusive ? "2" : "1") : "0");


### PR DESCRIPTION
VID_SyncCvars stored the window size in pixels, but vid_width/vid_height are read back as points by SDL_CreateWindow. vid_width/vid_height now hold points, matching SDL_SetWindowSize and the display mode list. There should be no change when pixel density is 1.

Fixes #1013 locally on my machine. Did not test on Windows or Linux.

I think VID_Toggle in gl_vidsdl.c has the same problem. It passes vid.width/vid.height to VID_SDL_GetDisplayMode, which matches against the display mode list in points. I can't tell what that code is doing well enough to make a change, so I left it out of this PR. 